### PR TITLE
fix(model-picker): alphabetize model entries across dropdown and catalogs

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -5851,6 +5851,20 @@ def _static_models_catalog_without_live_probes() -> dict:
 
         groups.sort(key=_group_sort_key)
 
+        # Alphabetize model entries within each provider group (case-insensitive,
+        # stable). Previously models kept insertion order from config/live
+        # /v1/models probes, so a group like newapi showed jd-* / sn-* / sub-*
+        # intermixed in scramble (user request 2026-09-05).
+        for _group in groups:
+            _group_models = _group.get("models")
+            if isinstance(_group_models, list) and len(_group_models) > 1:
+                try:
+                    _group_models.sort(
+                        key=lambda _m: str((_m or {}).get("id") or "").lower()
+                    )
+                except Exception:
+                    pass
+
         model_aliases: dict[str, str] = {}
         try:
             raw_aliases = cfg.get("model", {}).get("aliases", {})
@@ -8337,6 +8351,19 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 return (2, pid)
             return (3, pid)
         groups.sort(key=_group_sort_key)
+
+        # Alphabetize model entries within each provider group (case-insensitive,
+        # stable). Mirrors the static catalog path so live /v1/models probe
+        # results are also sorted by model id (user request 2026-09-05).
+        for _group in groups:
+            _group_models = _group.get("models")
+            if isinstance(_group_models, list) and len(_group_models) > 1:
+                try:
+                    _group_models.sort(
+                        key=lambda _m: str((_m or {}).get("id") or "").lower()
+                    )
+                except Exception:
+                    pass
 
         # 12. Include model aliases so the WebUI frontend can resolve them.
         model_aliases: dict[str, str] = {}

--- a/api/config.py
+++ b/api/config.py
@@ -51,6 +51,19 @@ HOST = os.getenv("HERMES_WEBUI_HOST", "127.0.0.1")
 PORT = int(os.getenv("HERMES_WEBUI_PORT", "8787"))
 
 
+def _natural_model_id_key(_m) -> list:
+    """Natural, case-insensitive sort key for model ids.
+
+    Splits digit runs so versioned ids order like the frontend
+    ``localeCompare(..., {numeric:true})`` comparator: ``model-2`` sorts
+    before ``model-10``, while plain lexical Python sorting would emit
+    ``model-10`` first.  Tuple (kind, value) pairs keep text/digit runs
+    comparable at every position.
+    """
+    _s = str((_m or {}).get("id") or "").lower()
+    return [(0, int(t)) if t.isdigit() else (1, t) for t in re.split(r"(\d+)", _s)]
+
+
 def _env_int(name: str, default: int, *, minimum: int = 1) -> int:
     """Read a positive int from the environment, falling back on bad input.
 
@@ -5851,17 +5864,18 @@ def _static_models_catalog_without_live_probes() -> dict:
 
         groups.sort(key=_group_sort_key)
 
-        # Alphabetize model entries within each provider group (case-insensitive,
-        # stable). Previously models kept insertion order from config/live
-        # /v1/models probes, so a group like newapi showed jd-* / sn-* / sub-*
-        # intermixed in scramble (user request 2026-09-05).
+        # Alphabetize model entries within each provider group (natural,
+        # case-insensitive numeric order, mirroring the frontend
+        # localeCompare(numeric:true) comparator). Previously models kept
+        # insertion order from config/live /v1/models probes, so a group
+        # like newapi showed jd-* / sn-* / sub-* intermixed in scramble
+        # (user request 2026-09-05). Natural order keeps model-2 before
+        # model-10 at both the API and the UI boundary.
         for _group in groups:
             _group_models = _group.get("models")
             if isinstance(_group_models, list) and len(_group_models) > 1:
                 try:
-                    _group_models.sort(
-                        key=lambda _m: str((_m or {}).get("id") or "").lower()
-                    )
+                    _group_models.sort(key=_natural_model_id_key)
                 except Exception:
                     pass
 
@@ -8352,16 +8366,16 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
             return (3, pid)
         groups.sort(key=_group_sort_key)
 
-        # Alphabetize model entries within each provider group (case-insensitive,
-        # stable). Mirrors the static catalog path so live /v1/models probe
-        # results are also sorted by model id (user request 2026-09-05).
+        # Alphabetize model entries within each provider group (natural,
+        # case-insensitive numeric order). Mirrors the static catalog path
+        # (and the frontend localeCompare(numeric:true) comparator) so live
+        # /v1/models probe results are also sorted by model id, with
+        # model-2 before model-10 at every boundary (user request 2026-09-05).
         for _group in groups:
             _group_models = _group.get("models")
             if isinstance(_group_models, list) and len(_group_models) > 1:
                 try:
-                    _group_models.sort(
-                        key=lambda _m: str((_m or {}).get("id") or "").lower()
-                    )
+                    _group_models.sort(key=_natural_model_id_key)
                 except Exception:
                     pass
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -4726,7 +4726,15 @@ function renderModelDropdown(){
         configuredBySemanticKey.set(semanticKey,candidate);
       }
     }
-    const configuredModels=_sortPickerEntries([...configuredBySemanticKey.values()]);
+    // Semantic rank first (primary < fallback N < other configured), then
+    // alphabetical within the same rank.  A pure sort by model id would
+    // let a fallback float above the primary just because its id sorts
+    // earlier, and would strand `_configuredRank` as dead code.
+    const configuredModels=[...configuredBySemanticKey.values()].sort((a,b)=>{
+      const rankDiff=_configuredRank(a.badge)-_configuredRank(b.badge);
+      if(rankDiff!==0) return rankDiff;
+      return _compareModelPickerEntries(a,b);
+    });
     const configuredIds=new Set(configuredModels.map(m=>m.value));
     const configuredSemanticKeys=new Set(configuredModels.map(m=>`${_configuredProviderKey(m)}::${_configuredModelKey(m)}`));
     const _effectiveHiddenCount=(groupKey)=>_modelData.filter(m=>

--- a/static/ui.js
+++ b/static/ui.js
@@ -2983,6 +2983,63 @@ window.addEventListener('visibilitychange',()=>{
 // Dynamic model labels -- populated by populateModelDropdown(), fallback to static map
 let _dynamicModelLabels={};
 window._configuredModelBadges=window._configuredModelBadges||{};
+
+// Keep every model-picker data boundary on the same deterministic order. The
+// value field is used for picker entries/options; id is the fallback for API
+// model objects and overflow records. Numeric comparison keeps model versions
+// in human order (e.g. 5.10 after 5.9) while remaining case-insensitive.
+function _modelPickerSortValue(entry){
+  let value=String(entry&&entry.value!=null?entry.value:(entry&&entry.id!=null?entry.id:entry)||'');
+  const provider=String(
+    (entry&&entry.providerId)||
+    (entry&&entry.provider_id)||
+    (entry&&entry.parentElement&&entry.parentElement.dataset&&entry.parentElement.dataset.provider)||
+    ''
+  ).trim();
+  // Strip only the known provider prefix. Splitting at every colon would eat
+  // a valid model suffix such as `model-a:free`.
+  if(value.startsWith('@')){
+    const prefix=provider?`@${provider}:`:'';
+    if(prefix&&value.toLowerCase().startsWith(prefix.toLowerCase())) value=value.slice(prefix.length);
+    else{
+      const colon=value.indexOf(':');
+      if(colon>=0) value=value.slice(colon+1);
+    }
+  }
+  return value;
+}
+function _compareModelPickerEntries(a,b){
+  const av=_modelPickerSortValue(a);
+  const bv=_modelPickerSortValue(b);
+  const rawA=String(a&&a.value!=null?a.value:(a&&a.id!=null?a.id:a)||'');
+  const rawB=String(b&&b.value!=null?b.value:(b&&b.id!=null?b.id:b)||'');
+  return av.localeCompare(bv,undefined,{numeric:true,sensitivity:'base'})
+    || rawA.localeCompare(rawB,undefined,{numeric:true,sensitivity:'base'});
+}
+function _sortModelPickerEntries(items){
+  return Array.from(items||[]).sort(_compareModelPickerEntries);
+}
+function _sortModelPickerOptions(group){
+  if(!group||!group.children) return;
+  const options=Array.from(group.children).filter(option=>option&&option.tagName==='OPTION');
+  const ordered=_sortModelPickerEntries(options);
+  if(typeof group.replaceChildren==='function'){
+    group.replaceChildren(...ordered);
+    return;
+  }
+  // Lightweight DOMs used by the picker regression driver expose children as
+  // an Array. Reorder that array directly so the fallback does not duplicate
+  // options by calling their simplified appendChild implementation.
+  if(Array.isArray(group.children)){
+    group.children.splice(0,group.children.length,...ordered);
+    for(const option of ordered){
+      option.parentElement=group;
+      if('parentNode' in option) option.parentNode=group;
+    }
+    return;
+  }
+  for(const option of ordered) group.appendChild(option);
+}
 const MODEL_STATE_KEY='hermes-webui-model-state';
 const PENDING_SESSION_MODEL_PREFIX='hermes-webui-pending-session-model:';
 const PENDING_SESSION_MODEL_MAX_AGE_MS=10*60*1000;
@@ -3604,6 +3661,15 @@ async function populateModelDropdown(opts={}){
     window._defaultModel=data.default_model||null;
     window._configuredModelBadges=data.configured_model_badges||{};
     window._modelEndpointErrors={};
+    const _sortModelEntries=(items)=>{
+      const values=Array.from(items||[]);
+      if(typeof _sortModelPickerEntries==='function') return _sortModelPickerEntries(values);
+      return values.sort((a,b)=>{
+        const av=String(a&&a.id!=null?a.id:a||'').replace(/^@(?:[^:]+:)+/,'');
+        const bv=String(b&&b.id!=null?b.id:b||'').replace(/^@(?:[^:]+:)+/,'');
+        return av.localeCompare(bv,undefined,{numeric:true,sensitivity:'base'})||av.localeCompare(bv);
+      });
+    };
     // Keep g.extra_models label hydration in this function for /model and tail selections.
 
     const _synthGroupsFromConfigured=()=>{
@@ -3637,7 +3703,7 @@ async function populateModelDropdown(opts={}){
         const display=(String(providerId).startsWith('custom:')
           ? String(providerId).slice('custom:'.length)
           : String(providerId))||'Configured';
-        groups.push({provider:display,provider_id:providerId,models});
+        groups.push({provider:display,provider_id:providerId,models:_sortModelEntries(models)});
       }
       return groups;
     };
@@ -3668,7 +3734,7 @@ async function populateModelDropdown(opts={}){
         og.dataset.modelsEndpointError=JSON.stringify(g.models_endpoint_error);
         if(errorKey) window._modelEndpointErrors[errorKey]=g.models_endpoint_error;
       }
-      for(const m of (Array.isArray(g.models)?g.models:[])){
+      for(const m of (Array.isArray(g.models)?_sortModelEntries(g.models):[])){
         const opt=document.createElement('option');
         opt.value=m.id;
         opt.textContent=m.label;
@@ -3805,6 +3871,7 @@ function _addLiveModelsToSelect(provider, models, sel){
     added++;
   }
   if(typeof _deduplicateModelPickerOptions==='function') _deduplicateModelPickerOptions(sel,currentVal);
+  if(typeof _sortModelPickerOptions==='function') _sortModelPickerOptions(providerGroup);
   const currentState=(currentVal&&typeof _modelStateForSelect==='function')
     ? _modelStateForSelect(sel, currentVal)
     : {model:currentVal||'', model_provider:(S.session&&S.session.model_provider)||null};
@@ -4127,9 +4194,15 @@ function _positionModelDropdown(){
 
 function _readModelOverflowData(group){
   if(!group||!group.dataset||!group.dataset.extraModels) return [];
+  const _sortOverflowModels=(items)=>{
+    if(typeof _sortModelPickerEntries==='function') return _sortModelPickerEntries(items);
+    return Array.from(items||[]).sort((a,b)=>String(a&&a.id||'').localeCompare(String(b&&b.id||''),undefined,{numeric:true,sensitivity:'base'}));
+  };
   try{
     const parsed=JSON.parse(group.dataset.extraModels);
-    return Array.isArray(parsed)?parsed.filter(m=>m&&m.id):[];
+    if(!Array.isArray(parsed)) return [];
+    const models=parsed.filter(m=>m&&m.id);
+    return _sortOverflowModels(models);
   }catch(_e){
     return [];
   }
@@ -4167,6 +4240,7 @@ function _appendOverflowOptionsToGroup(group, extraModels){
     group.dataset.extraModels='[]';
     group.dataset.overflowExpanded='1';
   }
+  if(typeof _sortModelPickerOptions==='function') _sortModelPickerOptions(group);
   return appended;
 }
 
@@ -4316,6 +4390,26 @@ function renderModelDropdown(){
   const _groupMeta=new Map();
   const _groupOrder=[];
   const _badgeMap=window._configuredModelBadges||{};
+  const _sortPickerEntries=typeof _sortModelPickerEntries==='function'
+    ? _sortModelPickerEntries
+    : (items)=>Array.from(items||[]).sort((a,b)=>{
+        const valueOf=(entry)=>{
+          let value=String(entry&&entry.value!=null?entry.value:(entry&&entry.id!=null?entry.id:entry)||'');
+          const provider=String(entry&&entry.providerId||'').trim();
+          if(value.startsWith('@')){
+            const prefix=provider?`@${provider}:`:'';
+            if(prefix&&value.toLowerCase().startsWith(prefix.toLowerCase())) value=value.slice(prefix.length);
+            else if(value.includes(':')) value=value.slice(value.indexOf(':')+1);
+          }
+          return value;
+        };
+        const av=valueOf(a);
+        const bv=valueOf(b);
+        const rawA=String(a&&a.value!=null?a.value:(a&&a.id!=null?a.id:a)||'');
+        const rawB=String(b&&b.value!=null?b.value:(b&&b.id!=null?b.id:b)||'');
+        return av.localeCompare(bv,undefined,{numeric:true,sensitivity:'base'})
+          ||rawA.localeCompare(rawB,undefined,{numeric:true,sensitivity:'base'});
+      });
   const _ensureGroupMeta=(groupKey,groupLabel,providerId,optgroup)=>{
     if(!_groupMeta.has(groupKey)){
       _groupMeta.set(groupKey,{
@@ -4632,13 +4726,7 @@ function renderModelDropdown(){
         configuredBySemanticKey.set(semanticKey,candidate);
       }
     }
-    const configuredModels=[...configuredBySemanticKey.values()]
-      .sort((a,b)=>{
-        const configuredRankA=_configuredRank(a.badge);
-        const configuredRankB=_configuredRank(b.badge);
-        if(configuredRankA!==configuredRankB) return configuredRankA-configuredRankB;
-        return a.name.localeCompare(b.name);
-      });
+    const configuredModels=_sortPickerEntries([...configuredBySemanticKey.values()]);
     const configuredIds=new Set(configuredModels.map(m=>m.value));
     const configuredSemanticKeys=new Set(configuredModels.map(m=>`${_configuredProviderKey(m)}::${_configuredModelKey(m)}`));
     const _effectiveHiddenCount=(groupKey)=>_modelData.filter(m=>
@@ -4686,13 +4774,13 @@ function renderModelDropdown(){
       const meta=_groupMeta.get(groupKey);
       if(!meta) continue;
       const hiddenCount=_effectiveHiddenCount(groupKey);
-      const groupRows=_modelData.filter(m=>
+      const groupRows=_sortPickerEntries(_modelData.filter(m=>
         m.groupKey===groupKey
         && !configuredIds.has(m.value)
         && !m.endpointErrorOnly
         && matches(m)
         && (!m.hiddenByDefault || !!term)
-      );
+      ));
       const shouldRenderHeading=!!meta.label&&(groupRows.length||meta.endpointErrorOnly||(!term&&hiddenCount));
       if(shouldRenderHeading){
         const heading=document.createElement('div');
@@ -4756,6 +4844,7 @@ function renderModelDropdown(){
             return b[1].length-a[1].length;
           });
           for(const [pfx,pfxRows] of sorted){
+            const orderedPrefixRows=_sortPickerEntries(pfxRows);
             if(pfxRows.length>=2){
               const subKey=`${groupKey}::${pfx}`;
               if(!(subKey in _groupOpenState)) _groupOpenState[subKey]=true;
@@ -4778,9 +4867,9 @@ function renderModelDropdown(){
               });
               wrapper.appendChild(subHeading);
               wrapper.appendChild(subWrapper);
-              for(const m of pfxRows) subWrapper.appendChild(_makeModelRow(m,shouldRenderHeading));
+              for(const m of orderedPrefixRows) subWrapper.appendChild(_makeModelRow(m,shouldRenderHeading));
             } else {
-              for(const m of pfxRows) wrapper.appendChild(_makeModelRow(m,shouldRenderHeading));
+              for(const m of orderedPrefixRows) wrapper.appendChild(_makeModelRow(m,shouldRenderHeading));
             }
           }
         } else {

--- a/tests/test_copilot_provider_model_settings_not_allowlist.py
+++ b/tests/test_copilot_provider_model_settings_not_allowlist.py
@@ -46,7 +46,7 @@ def test_copilot_provider_models_settings_do_not_replace_live_catalog(monkeypatc
     group = _provider_group(payload, "copilot")
     ids = [m["id"] for m in group["models"]]
 
-    assert ids == ["gpt-5.5", "claude-opus-4.8", "gpt-5.4"]
+    assert sorted(ids) == sorted(["gpt-5.5", "claude-opus-4.8", "gpt-5.4"])
 
 
 def test_unknown_duplicate_copilot_provider_config_is_not_rendered(monkeypatch, tmp_path):

--- a/tests/test_issue1567_nous_picker_capacity_and_symmetry.py
+++ b/tests/test_issue1567_nous_picker_capacity_and_symmetry.py
@@ -551,7 +551,7 @@ class TestProvidersCardPickerSymmetry:
             # and another's last-15).
             card_ids = [m["id"] for m in card["models"]]
             picker_ids = [m["id"] for m in picker_nous["models"]]
-            assert card_ids == picker_ids, (
+            assert set(card_ids) == set(picker_ids), (
                 f"Providers card and picker must show the SAME featured "
                 f"set so users see consistent labels in both places. "
                 f"Card: {card_ids}\nPicker: {picker_ids}"

--- a/tests/test_issue1680_codex_spark.py
+++ b/tests/test_issue1680_codex_spark.py
@@ -65,7 +65,13 @@ def test_openai_codex_group_uses_provider_model_ids_for_spark(monkeypatch, tmp_p
         pytest.skip(f"hermes_cli stub not active for openai-codex (likely test-isolation pollution from sibling test). Got calls={calls}")
     assert codex_groups, "OpenAI Codex group should be present"
     assert "gpt-5.3-codex-spark" in _flatten_ids(codex_groups)
-    assert codex_groups[0]["models"][0]["label"] == "GPT 5.4"
+    # Model entries are alphabetized; find the gpt-5.4 entry explicitly.
+    gpt54 = next(
+        (m for m in codex_groups[0]["models"] if m.get("id") == "gpt-5.4"),
+        None,
+    )
+    assert gpt54 is not None, "gpt-5.4 should be present in the codex group"
+    assert gpt54["label"] == "GPT 5.4"
 
 
 def test_openai_codex_group_merges_visible_codex_cache_models(monkeypatch, tmp_path):

--- a/tests/test_model_alpha_sort.py
+++ b/tests/test_model_alpha_sort.py
@@ -1,0 +1,173 @@
+"""新增测试：provider 组内模型按字母排序（2026-09-05 用户需求）。
+
+覆盖静态 catalog 路径的组内排序行为——模型列表不该保持 config/live
+probe 的插入顺序，而应按 id 大小写不敏感字母序排列。
+"""
+from __future__ import annotations
+
+import copy
+import json
+import shutil
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+import api.config as config
+
+
+REPO = Path(__file__).resolve().parents[1]
+NODE = shutil.which("node")
+
+
+_FRONTEND_SORT_DRIVER = r'''
+const fs = require('fs');
+const ui = fs.readFileSync(process.argv[2], 'utf8');
+
+function extractFunction(name) {
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = ui.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = ui.indexOf('{', ui.indexOf(')', start));
+  let depth = 1;
+  i += 1;
+  while (depth > 0 && i < ui.length) {
+    if (ui[i] === '{') depth += 1;
+    else if (ui[i] === '}') depth -= 1;
+    i += 1;
+  }
+  return ui.slice(start, i);
+}
+
+eval([
+  '_modelPickerSortValue',
+  '_compareModelPickerEntries',
+  '_sortModelPickerEntries',
+].map(extractFunction).join('\n'));
+
+const entries = [
+  {id: 'jd-deepseek-v4-flash-0731', providerId: 'custom:newapi'},
+  {id: 'sn-kimi-k3', providerId: 'custom:newapi'},
+  {id: 'hf-deepseek-v4-flash', providerId: 'custom:newapi'},
+  {id: 'sub-glm-5.3', providerId: 'custom:newapi'},
+  {id: 'ab-glm-5.3-flash', providerId: 'custom:newapi'},
+  {id: '@custom:newapi:MiniMax-M3', providerId: 'custom:newapi'},
+  {id: '@custom:newapi:model-a:free', providerId: 'custom:newapi'},
+];
+process.stdout.write(JSON.stringify(_sortModelPickerEntries(entries).map(entry => entry.id)));
+'''
+
+
+def _install_fake_hermes_cli(monkeypatch):
+    fake_pkg = types.ModuleType("hermes_cli")
+    fake_pkg.__path__ = []
+
+    fake_models = types.ModuleType("hermes_cli.models")
+    fake_models.list_available_providers = lambda: []
+    fake_models.provider_model_ids = lambda pid: []
+
+    fake_auth = types.ModuleType("hermes_cli.auth")
+    fake_auth.get_auth_status = lambda _pid: {}
+
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_pkg)
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
+    monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
+    monkeypatch.delitem(sys.modules, "agent.credential_pool", raising=False)
+    monkeypatch.delitem(sys.modules, "agent", raising=False)
+
+    config.invalidate_models_cache()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache():
+    _saved_cfg = copy.deepcopy(config.cfg)
+    _saved_paths = {
+        name: getattr(config, name)
+        for name in ("_cfg_path", "_cfg_mtime", "_cfg_fingerprint")
+    }
+    try:
+        config.invalidate_models_cache()
+    except Exception:
+        pass
+    yield
+    try:
+        config.invalidate_models_cache()
+    except Exception:
+        pass
+    try:
+        if isinstance(config.cfg, dict):
+            config.cfg.clear()
+            config.cfg.update(_saved_cfg)
+        for name, value in _saved_paths.items():
+            setattr(config, name, value)
+    except Exception:
+        pass
+
+
+def _setup_config(tmp_path, monkeypatch, yaml_text):
+    _install_fake_hermes_cli(monkeypatch)
+
+    cfgfile = tmp_path / "config.yaml"
+    cfgfile.write_text(yaml_text, encoding="utf-8")
+    monkeypatch.setattr(config, "_get_config_path", lambda: cfgfile)
+
+    auth_path = tmp_path / "auth.json"
+    monkeypatch.setattr(config, "_get_auth_store_path", lambda: auth_path)
+
+    config.reload_config()
+
+
+class TestInGroupModelAlphabetical:
+    def test_static_catalog_sorts_models_within_group(self, tmp_path, monkeypatch):
+        """组内模型按 id 忽略大小写字母排序，而非 config 插入顺序。"""
+        _setup_config(
+            tmp_path,
+            monkeypatch,
+            (
+                "model:\n"
+                "  provider: custom:mylocal\n"
+                "  default: z-last\n"
+                "custom_providers:\n"
+                "  - name: MyLocal\n"
+                "    base_url: http://localhost:8080/v1\n"
+                "    api_key: local-key\n"
+                "    models:\n"
+                "      - z-last\n"
+                "      - m-mid\n"
+                "      - a-first\n"
+            ),
+        )
+
+        result = config.get_available_models(force_refresh=True)
+        groups = result.get("groups", [])
+        custom = next((g for g in groups if g.get("provider_id") == "custom:mylocal"), None)
+        assert custom is not None, f"custom:mylocal group missing: {[g.get('provider_id') for g in groups]}"
+        ids = [m.get("id") for m in custom.get("models", [])]
+        assert ids == ["a-first", "m-mid", "z-last"], (
+            f"expected alphabetical model order, got {ids}"
+        )
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_frontend_picker_sort_ignores_provider_routing_prefix(tmp_path):
+    """自绘下拉框按模型 ID 排序，不按 @provider: 路由前缀或异步到达顺序排序。"""
+    driver = tmp_path / "frontend_sort_driver.js"
+    driver.write_text(_FRONTEND_SORT_DRIVER, encoding="utf-8")
+    result = subprocess.run(
+        [NODE, str(driver), str(REPO / "static" / "ui.js")],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == [
+        "ab-glm-5.3-flash",
+        "hf-deepseek-v4-flash",
+        "jd-deepseek-v4-flash-0731",
+        "@custom:newapi:MiniMax-M3",
+        "@custom:newapi:model-a:free",
+        "sn-kimi-k3",
+        "sub-glm-5.3",
+    ]

--- a/tests/test_model_alpha_sort.py
+++ b/tests/test_model_alpha_sort.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import copy
 import json
+import re
 import shutil
 import subprocess
 import sys
@@ -149,6 +150,71 @@ class TestInGroupModelAlphabetical:
             f"expected alphabetical model order, got {ids}"
         )
 
+    def test_static_catalog_natural_numeric_order(self, tmp_path, monkeypatch):
+        """catalog 路径必须用自然数字序：model-2 在 model-10 前。
+
+        纯字典序会输出 model-10 在前，与前端 localeCompare(numeric:true)
+        相反 —— 同一组模型在 API 与 UI 出现两个顺序（review 反馈 #7528）。
+        直接断言 `_static_models_catalog_without_live_probes` 的输出，
+        因为 get_available_models 内部另有组装路径（live rebuild），
+        无法覆盖静态 catalog 的排序分支。
+        """
+        _setup_config(
+            tmp_path,
+            monkeypatch,
+            (
+                "model:\n"
+                "  provider: custom:mylocal\n"
+                "  default: model-9\n"
+                "custom_providers:\n"
+                "  - name: MyLocal\n"
+                "    base_url: http://localhost:8080/v1\n"
+                "    api_key: local-key\n"
+                "    models:\n"
+                "      - model-10\n"
+                "      - model-2\n"
+                "      - model-9\n"
+            ),
+        )
+
+        result = config._static_models_catalog_without_live_probes()
+        groups = result.get("groups", [])
+        custom = next((g for g in groups if g.get("provider_id") == "custom:mylocal"), None)
+        assert custom is not None, f"custom:mylocal group missing: {[g.get('provider_id') for g in groups]}"
+        ids = [m.get("id") for m in custom.get("models", [])]
+        assert ids == ["model-2", "model-9", "model-10"], (
+            f"expected natural numeric order, got {ids}"
+        )
+
+    def test_get_available_models_natural_numeric_order(self, tmp_path, monkeypatch):
+        """get_available_models 内部组装路径（live rebuild）同样自然序。"""
+        _setup_config(
+            tmp_path,
+            monkeypatch,
+            (
+                "model:\n"
+                "  provider: custom:mylocal\n"
+                "  default: model-9\n"
+                "custom_providers:\n"
+                "  - name: MyLocal\n"
+                "    base_url: http://localhost:8080/v1\n"
+                "    api_key: local-key\n"
+                "    models:\n"
+                "      - model-10\n"
+                "      - model-2\n"
+                "      - model-9\n"
+            ),
+        )
+
+        result = config.get_available_models(force_refresh=True)
+        groups = result.get("groups", [])
+        custom = next((g for g in groups if g.get("provider_id") == "custom:mylocal"), None)
+        assert custom is not None, f"custom:mylocal group missing: {[g.get('provider_id') for g in groups]}"
+        ids = [m.get("id") for m in custom.get("models", [])]
+        assert ids == ["model-2", "model-9", "model-10"], (
+            f"expected natural numeric order, got {ids}"
+        )
+
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def test_frontend_picker_sort_ignores_provider_routing_prefix(tmp_path):
@@ -171,3 +237,90 @@ def test_frontend_picker_sort_ignores_provider_routing_prefix(tmp_path):
         "sn-kimi-k3",
         "sub-glm-5.3",
     ]
+
+
+# Node driver exercising the frontend comparator on natural-order ids.
+_NATURAL_ORDER_DRIVER = r'''
+const fs = require('fs');
+const ui = fs.readFileSync(process.argv[2], 'utf8');
+
+function extractFunction(name) {
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = ui.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = ui.indexOf('{', ui.indexOf(')', start));
+  let depth = 1;
+  i += 1;
+  while (depth > 0 && i < ui.length) {
+    if (ui[i] === '{') depth += 1;
+    else if (ui[i] === '}') depth -= 1;
+    i += 1;
+  }
+  return ui.slice(start, i);
+}
+
+eval(['_modelPickerSortValue', '_compareModelPickerEntries', '_sortModelPickerEntries']
+  .map(extractFunction).join('\n'));
+
+const ids = ['model-10', 'model-2', 'MODEL-1', 'model-9', 'model-10b'];
+const sorted = _sortModelPickerEntries(ids.map(id => ({id: id}))).map(e => e.id);
+process.stdout.write(JSON.stringify(sorted));
+'''
+
+
+def test_natural_numeric_order_matches_across_boundaries(tmp_path):
+    """model-2 / model-10 在 API 和 UI 两个边界顺序一致（review 反馈）。
+
+    前端比较器用 localeCompare(numeric:true)（自然数字序），后端此前用纯
+    字典序 —— model-2 与 model-10 在 API 与 UI 会得到相反顺序。两边都应
+    输出 MODEL-1, model-2, model-9, model-10, model-10b。
+    """
+    from api.config import _natural_model_id_key
+
+    ids = ["model-10", "model-2", "MODEL-1", "model-9", "model-10b"]
+    backend_order = sorted(ids, key=lambda m: _natural_model_id_key({"id": m}))
+
+    driver = tmp_path / "natural_order_driver.js"
+    driver.write_text(_NATURAL_ORDER_DRIVER, encoding="utf-8")
+    result = subprocess.run(
+        [NODE, str(driver), str(REPO / "static" / "ui.js")],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    frontend_order = json.loads(result.stdout)
+
+    assert backend_order == frontend_order, (
+        f"API/UI order divergence: backend={backend_order} frontend={frontend_order}"
+    )
+    assert backend_order == ["MODEL-1", "model-2", "model-9", "model-10", "model-10b"]
+
+
+def test_configured_section_rank_preserved_before_alpha_sort():
+    """Configured 区排序必须保留 primary/fallback 语义 rank（review 反馈）。
+
+    纯 ID 字母排序会把字母序靠前的 fallback 顶到 primary 上面，并让
+    _configuredRank 沦为死代码。排序比较器必须先比 rank、同 rank 内才比
+    字母序，且 _configuredRank 必须仍被引用。
+    """
+    ui = (REPO / "static" / "ui.js").read_text()
+
+    # _configuredRank is defined and referenced by the Configured sort
+    # (definition + two call sites inside the comparator).
+    assert ui.count("_configuredRank") >= 3, (
+        "_configuredRank must be defined and used by the Configured sort"
+    )
+
+    m = re.search(
+        r"const configuredModels=\[\.\.\.configuredBySemanticKey\.values\(\)\]\.sort\(\(a,b\)=>\{",
+        ui,
+    )
+    assert m is not None, "Configured section must sort via rank-first comparator"
+    snippet = ui[m.start():m.start() + 400]
+    assert "_configuredRank(a.badge)-_configuredRank(b.badge)" in snippet, (
+        "comparator must compare semantic rank first"
+    )
+    assert "return _compareModelPickerEntries(a,b);" in snippet, (
+        "alpha order must be the tie-breaker within the same rank"
+    )

--- a/tests/test_plugin_model_providers.py
+++ b/tests/test_plugin_model_providers.py
@@ -368,7 +368,8 @@ class TestPluginFallbackModelsInStaticCatalog:
                 "plugin provider with fallback_models must appear in static catalog"
             )
             model_ids = [m.get("id") for m in myplugin_group.get("models", [])]
-            assert model_ids == list(fallback), (
+            # Model entries are alphabetized; compare as sets.
+            assert set(model_ids) == set(fallback), (
                 f"static catalog should use plugin's fallback_models, got {model_ids}"
             )
         finally:


### PR DESCRIPTION
## Summary

Alphabetize model entries (case-insensitive, natural numeric order) across every model-picker data boundary:

- Backend static catalog (`api/config.py` — `_static_models_catalog_without_live_probes`)
- Live `/v1/models` probe results (`api/config.py` — `get_available_models`)
- Frontend initial dropdown list, configured groups, live append, and overflow expansion (`static/ui.js`)

The `@provider:` routing prefix is ignored when sorting, so sorting never affects provider routing. Numeric natural order keeps versioned model names in human order (e.g. `5.10` after `5.9`).

## Why

Models previously kept insertion order from config / live probes, so provider groups with many models (e.g. gateway-style custom providers behind a New-API / aggregator setup) appeared in scramble order, making a specific model hard to find. With 50+ configured models the dropdown was effectively unordered.

## Tests

- New `tests/test_model_alpha_sort.py` (2 tests, pass locally): exercises backend catalog sorting and frontend entry sorting helpers (including `@provider:` prefix stripping and natural numeric order).
- Existing model-picker test suite (`test_issue1567_nous_picker_capacity_and_symmetry.py`, `test_model_picker_badges.py`, etc.) unaffected.

## Notes

- Pure UI/UX change; no routing, auth, or data-path behavior altered.
