### PR TITLE
fix(profiles): make the profile dropdown keyboard navigable

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -120,7 +120,7 @@
 <body>
 <header class="app-titlebar" role="banner">
   <div class="app-titlebar-left">
-    <button class="app-titlebar-profile" id="titlebarProfileBtn" type="button" onclick="toggleProfileDropdown(event)" aria-label="Switch profile" aria-haspopup="listbox" aria-expanded="false" aria-controls="profileDropdown" style="display:none">
+    <button class="app-titlebar-profile" id="titlebarProfileBtn" type="button" onclick="toggleProfileDropdown(event)" aria-label="Switch profile" aria-haspopup="menu" aria-expanded="false" aria-controls="profileDropdown" style="display:none">
       <span class="app-titlebar-profile-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>
       <span class="app-titlebar-profile-label" id="titlebarProfileLabel">default</span>
       <span class="app-titlebar-profile-chevron" aria-hidden="true"><svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span>
@@ -628,7 +628,7 @@
               <span class="yolo-pill-label" data-i18n="yolo_pill_label">YOLO</span>
             </button>
             <div id="profileChipWrap" class="composer-profile-wrap">
-              <button class="composer-profile-chip profile-chip" id="profileChip" type="button" onclick="toggleProfileDropdown()" title="Switch profile" aria-haspopup="listbox" aria-expanded="false" aria-controls="profileDropdown">
+              <button class="composer-profile-chip profile-chip" id="profileChip" type="button" onclick="toggleProfileDropdown()" title="Switch profile" aria-haspopup="menu" aria-expanded="false" aria-controls="profileDropdown">
                 <span class="composer-profile-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>
                 <span class="composer-profile-label" id="profileChipLabel">default</span>
                 <span class="composer-profile-chevron" aria-hidden="true"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span>

--- a/static/index.html
+++ b/static/index.html
@@ -120,7 +120,7 @@
 <body>
 <header class="app-titlebar" role="banner">
   <div class="app-titlebar-left">
-    <button class="app-titlebar-profile" id="titlebarProfileBtn" type="button" onclick="toggleProfileDropdown(event)" aria-label="Switch profile" style="display:none">
+    <button class="app-titlebar-profile" id="titlebarProfileBtn" type="button" onclick="toggleProfileDropdown(event)" aria-label="Switch profile" aria-haspopup="listbox" aria-expanded="false" aria-controls="profileDropdown" style="display:none">
       <span class="app-titlebar-profile-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>
       <span class="app-titlebar-profile-label" id="titlebarProfileLabel">default</span>
       <span class="app-titlebar-profile-chevron" aria-hidden="true"><svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span>
@@ -628,7 +628,7 @@
               <span class="yolo-pill-label" data-i18n="yolo_pill_label">YOLO</span>
             </button>
             <div id="profileChipWrap" class="composer-profile-wrap">
-              <button class="composer-profile-chip profile-chip" id="profileChip" type="button" onclick="toggleProfileDropdown()" title="Switch profile">
+              <button class="composer-profile-chip profile-chip" id="profileChip" type="button" onclick="toggleProfileDropdown()" title="Switch profile" aria-haspopup="listbox" aria-expanded="false" aria-controls="profileDropdown">
                 <span class="composer-profile-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>
                 <span class="composer-profile-label" id="profileChipLabel">default</span>
                 <span class="composer-profile-chevron" aria-hidden="true"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span>

--- a/static/panels.js
+++ b/static/panels.js
@@ -6488,6 +6488,10 @@ const PROFILE_DROPDOWN_CACHE_TTL_MS = 5 * 60 * 1000;
 let _profileSwitchGeneration = 0;
 let _profileDropdownTrigger = null;  // tracks which element triggered the dropdown
 let _profileDropdownOpenGeneration = 0;
+// data-profile of the option that currently holds keyboard focus inside the
+// open menu. Survives re-renders (the focused node is detached by innerHTML='',
+// so identity must be tracked by name) and is null until the first focus lands.
+let _profileDropdownFocusedName = null;
 
 function _profileDropdownClearStoredCache(){
   try{localStorage.removeItem(PROFILE_DROPDOWN_CACHE_KEY);}catch(_){}
@@ -6869,6 +6873,7 @@ function renderProfileDropdown(data) {
     opt.setAttribute('role','option');
     opt.setAttribute('tabindex','-1');
     opt.setAttribute('aria-selected', p.name === active ? 'true' : 'false');
+    opt.setAttribute('data-profile', p.name);
     const meta = [];
     if (typeof p.model === 'string' && p.model) meta.push(p.model.split('/').pop());
     if (p.total_skills && p.total_skills > 0) meta.push(t('profile_skill_count', p.total_skills).replace(String(p.total_skills), `${p.enabled_skills} / ${p.total_skills}`));
@@ -6891,6 +6896,7 @@ function renderProfileDropdown(data) {
     mgmt.setAttribute('role','option');
     mgmt.setAttribute('tabindex','-1');
     mgmt.setAttribute('aria-label', t('manage_profiles'));
+    mgmt.setAttribute('data-profile', '__manage__');
     mgmt.innerHTML = `${li('settings',12)} ${esc(t('manage_profiles'))}`;
     mgmt.onclick = () => { closeProfileDropdown({restore:true}); mobileSwitchPanel('profiles'); };
     dd.appendChild(mgmt);
@@ -6949,6 +6955,7 @@ function toggleProfileDropdown(e) {
 function closeProfileDropdown(opts) {
   const restore = !!(opts && opts.restore === true);
   _profileDropdownOpenGeneration++;
+  _profileDropdownFocusedName = null;
   const dd = $('profileDropdown');
   if (dd) dd.classList.remove('open');
   const chip=$('profileChip');
@@ -6990,10 +6997,30 @@ function _focusProfileDropdownOption(){
   if(!dd || !dd.classList.contains('open')) return;
   const items=_profileDropdownOptions();
   if(!items.length) return;
-  let idx=items.findIndex(o=>o.getAttribute('aria-selected')==='true');
+  const fe=document.activeElement;
+  // Is focus attached to this menu interaction? Inside the menu, on one of the
+  // trigger buttons (the user just opened it), or a recently-focused option the
+  // refresh just detached (innerHTML='') — which is inside by the user's last
+  // interaction.
+  const focusAttached=!!(fe && (
+    fe===dd || dd.contains(fe)
+    || fe===$('profileChip') || fe===$('titlebarProfileBtn')
+    || (typeof fe.getAttribute==='function' && fe.getAttribute('data-profile') && fe.isConnected===false)
+  ));
+  // Never steal focus from the rest of the app: if the user Tabbed out of the
+  // menu, a background refresh must not yank focus back into it.
+  if(fe && fe!==document.body && !focusAttached) return;
+  let idx=-1;
+  // Preserve an in-progress keyboard selection across a background refresh:
+  // re-focus the rebuilt row with the same data-profile instead of jumping
+  // back to the active one.
+  if(focusAttached) idx=items.findIndex(o=>o.getAttribute('data-profile')===_profileDropdownFocusedName);
+  if(idx<0) idx=items.findIndex(o=>o.getAttribute('aria-selected')==='true');
   if(idx<0) idx=0;
   const target=items[idx];
-  if(target && target!==document.activeElement){
+  if(target && target!==fe){
+    const profileName=target.getAttribute('data-profile');
+    if(profileName) _profileDropdownFocusedName=profileName;
     try{target.focus({preventScroll:true});}catch(_){target.focus();}
   }
 }
@@ -7001,6 +7028,10 @@ function _focusProfileDropdownOption(){
 function _profileDropdownKeydownHandler(e){
   const dd=$('profileDropdown');
   if(!dd || !dd.classList.contains('open')) return;
+  // Scope the handler to the menu: once focus has left the listbox (e.g. Tab),
+  // Arrow/Home/End/Enter/Escape must keep working in the rest of the app, not
+  // be hijacked by an open menu the user has moved away from.
+  if(dd.contains(document.activeElement)===false) return;
   const items=_profileDropdownOptions();
   if(e.key==='Escape'){
     e.preventDefault();
@@ -7018,6 +7049,8 @@ function _profileDropdownKeydownHandler(e){
   if(next>=0 && next!==current){
     e.preventDefault();
     const target=items[next];
+    const profileName=target.getAttribute('data-profile');
+    if(profileName) _profileDropdownFocusedName=profileName;
     try{target.focus({preventScroll:true});}catch(_){target.focus();}
     return;
   }

--- a/static/panels.js
+++ b/static/panels.js
@@ -6577,9 +6577,9 @@ function _openProfileDropdownShell(){
   dd.classList.add('open');
   _positionProfileDropdown();
   const chip=$('profileChip');
-  if(chip && _profileDropdownTrigger===chip) chip.classList.add('active');
+  if(chip && _profileDropdownTrigger===chip){ chip.classList.add('active'); chip.setAttribute('aria-expanded','true'); }
   const tbtn=$('titlebarProfileBtn');
-  if(tbtn && _profileDropdownTrigger===tbtn) tbtn.classList.add('active');
+  if(tbtn && _profileDropdownTrigger===tbtn){ tbtn.classList.add('active'); tbtn.setAttribute('aria-expanded','true'); }
 }
 
 async function _profileSwitchPanelLoad(){
@@ -6852,6 +6852,12 @@ function renderProfileDropdown(data) {
   const dd = $('profileDropdown');
   if (!dd) return;
   dd.innerHTML = '';
+  // ARIA listbox contract: the menu is a keyboard-navigable list of options
+  // (ArrowUp/Down/Home/End move focus, Enter/Space selects, Escape closes).
+  // Options get role="option" + tabindex="-1" + aria-selected so screen readers
+  // and keyboard users see the same structure mouse users see.
+  dd.setAttribute('role','listbox');
+  dd.setAttribute('aria-label', t('tab_profiles') || 'Profiles');
   const allProfiles = (Array.isArray(data.profiles) ? data.profiles : []).filter(p => p && typeof p.name === 'string');
   const active = (S.activeProfile && allProfiles.some(p => p.name === S.activeProfile))
     ? S.activeProfile
@@ -6860,6 +6866,9 @@ function renderProfileDropdown(data) {
   for (const p of profiles) {
     const opt = document.createElement('div');
     opt.className = 'profile-opt' + (p.name === active ? ' active' : '');
+    opt.setAttribute('role','option');
+    opt.setAttribute('tabindex','-1');
+    opt.setAttribute('aria-selected', p.name === active ? 'true' : 'false');
     const meta = [];
     if (typeof p.model === 'string' && p.model) meta.push(p.model.split('/').pop());
     if (p.total_skills && p.total_skills > 0) meta.push(t('profile_skill_count', p.total_skills).replace(String(p.total_skills), `${p.enabled_skills} / ${p.total_skills}`));
@@ -6869,7 +6878,7 @@ function renderProfileDropdown(data) {
     opt.innerHTML = `<div class="profile-opt-name">${gwDot}${esc(p.name)}${defaultBadge}${checkmark}</div>` +
       (meta.length ? `<div class="profile-opt-meta">${esc(meta.join(' \u00b7 '))}</div>` : '');
     opt.onclick = async () => {
-      closeProfileDropdown();
+      closeProfileDropdown({restore:true});
       if (p.name === active) return;
       await switchToProfile(p.name);
     };
@@ -6879,13 +6888,20 @@ function renderProfileDropdown(data) {
   if (!data.single_profile_mode) {
     const div = document.createElement('div'); div.className = 'ws-divider'; dd.appendChild(div);
     const mgmt = document.createElement('div'); mgmt.className = 'profile-opt ws-manage';
+    mgmt.setAttribute('role','option');
+    mgmt.setAttribute('tabindex','-1');
+    mgmt.setAttribute('aria-label', t('manage_profiles'));
     mgmt.innerHTML = `${li('settings',12)} ${esc(t('manage_profiles'))}`;
-    mgmt.onclick = () => { closeProfileDropdown(); mobileSwitchPanel('profiles'); };
+    mgmt.onclick = () => { closeProfileDropdown({restore:true}); mobileSwitchPanel('profiles'); };
     dd.appendChild(mgmt);
   }
   // Sync titlebar label to the resolved active profile
   const tbl = $('titlebarProfileLabel');
   if (tbl) tbl.textContent = active;
+  // Keyboard users: move focus into the just-rendered menu so ArrowUp/Down +
+  // Enter work immediately without an extra click (matches the session action
+  // menu focus-on-open behavior).
+  _focusProfileDropdownOption();
 }
 
 function toggleProfileDropdown(e) {
@@ -6900,8 +6916,11 @@ function toggleProfileDropdown(e) {
   const cached = _profileDropdownBestCachedData();
 
   if(cached && !cached.single_profile_mode){
-    renderProfileDropdown(cached);
+    // Open the shell BEFORE rendering: _focusProfileDropdownOption() only acts
+    // while the menu is open, so render-while-closed would silently drop the
+    // focus-on-open behavior.
     _openProfileDropdownShell();
+    renderProfileDropdown(cached);
   }else{
     _renderProfileDropdownLoading();
     _openProfileDropdownShell();
@@ -6914,8 +6933,8 @@ function toggleProfileDropdown(e) {
       closeProfileDropdown();
       return;
     }
-    renderProfileDropdown(data);
     _openProfileDropdownShell();
+    renderProfileDropdown(data);
   }).catch(e => {
     if(openGen !== _profileDropdownOpenGeneration) return;
     if(cached && !cached.single_profile_mode){
@@ -6927,14 +6946,24 @@ function toggleProfileDropdown(e) {
   });
 }
 
-function closeProfileDropdown() {
+function closeProfileDropdown(opts) {
+  const restore = !!(opts && opts.restore === true);
   _profileDropdownOpenGeneration++;
   const dd = $('profileDropdown');
   if (dd) dd.classList.remove('open');
   const chip=$('profileChip');
-  if(chip) chip.classList.remove('active');
+  if(chip){ chip.classList.remove('active'); chip.setAttribute('aria-expanded','false'); }
   const tbtn=$('titlebarProfileBtn');
-  if(tbtn) tbtn.classList.remove('active');
+  if(tbtn){ tbtn.classList.remove('active'); tbtn.setAttribute('aria-expanded','false'); }
+  if(restore){
+    // Only yank focus back when the keyboard asked for it (Escape / selection).
+    // Click-outside closes must not steal focus from wherever the user moved.
+    const trigger=_profileDropdownTrigger||chip;
+    const focusInside=dd && document.activeElement && dd.contains(document.activeElement);
+    if(trigger && trigger.isConnected && focusInside && typeof trigger.focus==='function'){
+      try{trigger.focus({preventScroll:true});}catch(_){trigger.focus();}
+    }
+  }
 }
 document.addEventListener('click', e => {
   if (!e.target.closest('#profileChipWrap') && !e.target.closest('#titlebarProfileBtn') && !e.target.closest('#profileDropdown')) closeProfileDropdown();
@@ -6942,6 +6971,77 @@ document.addEventListener('click', e => {
 window.addEventListener('resize',()=>{
   const dd=$('profileDropdown');
   if(dd&&dd.classList.contains('open')) _positionProfileDropdown();
+});
+
+// ── Profile dropdown keyboard navigation ─────────────────────────────────────
+// The dropdown is a plain-div menu, so it previously had NO keyboard support:
+// opening it (click or Enter) left focus on the trigger and ArrowUp/Down did
+// nothing, forcing mouse-only selection. Mirror the session action menu pattern
+// (sessions.js _mountSessionActionMenu): options are focusable, arrow keys move
+// focus, Enter/Space select, Escape closes and returns focus to the trigger.
+
+function _profileDropdownOptions(){
+  const dd=$('profileDropdown');
+  return dd ? Array.from(dd.querySelectorAll('.profile-opt')) : [];
+}
+
+function _focusProfileDropdownOption(){
+  const dd=$('profileDropdown');
+  if(!dd || !dd.classList.contains('open')) return;
+  const items=_profileDropdownOptions();
+  if(!items.length) return;
+  let idx=items.findIndex(o=>o.getAttribute('aria-selected')==='true');
+  if(idx<0) idx=0;
+  const target=items[idx];
+  if(target && target!==document.activeElement){
+    try{target.focus({preventScroll:true});}catch(_){target.focus();}
+  }
+}
+
+function _profileDropdownKeydownHandler(e){
+  const dd=$('profileDropdown');
+  if(!dd || !dd.classList.contains('open')) return;
+  const items=_profileDropdownOptions();
+  if(e.key==='Escape'){
+    e.preventDefault();
+    e.stopPropagation();
+    closeProfileDropdown({restore:true});
+    return;
+  }
+  if(!items.length) return;
+  const current=items.indexOf(document.activeElement);
+  let next=-1;
+  if(e.key==='ArrowDown') next=(current+1)%items.length;
+  else if(e.key==='ArrowUp') next=(current-1+items.length)%items.length;
+  else if(e.key==='Home') next=0;
+  else if(e.key==='End') next=items.length-1;
+  if(next>=0 && next!==current){
+    e.preventDefault();
+    const target=items[next];
+    try{target.focus({preventScroll:true});}catch(_){target.focus();}
+    return;
+  }
+  if((e.key==='Enter'||e.key===' ') && current>=0){
+    // Only activate when an option (or the manage row) actually holds focus;
+    // otherwise let the key pass through (e.g. Tab moved focus to the composer).
+    e.preventDefault();
+    items[current].click();
+  }
+}
+document.addEventListener('keydown', _profileDropdownKeydownHandler);
+
+// ArrowUp/Down on the trigger opens the menu and moves focus onto the first
+// option (native Enter/Space on a button already opens it via click).
+['profileChip','titlebarProfileBtn'].forEach(id=>{
+  const el=$(id);
+  if(!el) return;
+  el.addEventListener('keydown', e=>{
+    if(e.key!=='ArrowDown' && e.key!=='ArrowUp') return;
+    const dd=$('profileDropdown');
+    if(dd && dd.classList.contains('open')) return; // menu handler moves focus
+    e.preventDefault();
+    toggleProfileDropdown(e);
+  });
 });
 
 function _openProfileSwitchSessionBrowser(){

--- a/static/panels.js
+++ b/static/panels.js
@@ -6856,11 +6856,12 @@ function renderProfileDropdown(data) {
   const dd = $('profileDropdown');
   if (!dd) return;
   dd.innerHTML = '';
-  // ARIA listbox contract: the menu is a keyboard-navigable list of options
-  // (ArrowUp/Down/Home/End move focus, Enter/Space selects, Escape closes).
-  // Options get role="option" + tabindex="-1" + aria-selected so screen readers
-  // and keyboard users see the same structure mouse users see.
-  dd.setAttribute('role','listbox');
+  // ARIA menu-button contract: the popup is a menu whose rows the user chooses
+  // between, plus one navigation command (Manage profiles). A listbox would be
+  // wrong here — it is for selecting a *value*, and a command cannot be an
+  // option. role="menu"/"menuitem" fits both rows, and the active profile is
+  // marked with aria-current rather than aria-selected.
+  dd.setAttribute('role','menu');
   dd.setAttribute('aria-label', t('tab_profiles') || 'Profiles');
   const allProfiles = (Array.isArray(data.profiles) ? data.profiles : []).filter(p => p && typeof p.name === 'string');
   const active = (S.activeProfile && allProfiles.some(p => p.name === S.activeProfile))
@@ -6870,9 +6871,9 @@ function renderProfileDropdown(data) {
   for (const p of profiles) {
     const opt = document.createElement('div');
     opt.className = 'profile-opt' + (p.name === active ? ' active' : '');
-    opt.setAttribute('role','option');
+    opt.setAttribute('role','menuitem');
     opt.setAttribute('tabindex','-1');
-    opt.setAttribute('aria-selected', p.name === active ? 'true' : 'false');
+    if (p.name === active) opt.setAttribute('aria-current','true');
     opt.setAttribute('data-profile', p.name);
     const meta = [];
     if (typeof p.model === 'string' && p.model) meta.push(p.model.split('/').pop());
@@ -6893,12 +6894,18 @@ function renderProfileDropdown(data) {
   if (!data.single_profile_mode) {
     const div = document.createElement('div'); div.className = 'ws-divider'; dd.appendChild(div);
     const mgmt = document.createElement('div'); mgmt.className = 'profile-opt ws-manage';
-    mgmt.setAttribute('role','option');
+    mgmt.setAttribute('role','menuitem');
     mgmt.setAttribute('tabindex','-1');
-    mgmt.setAttribute('aria-label', t('manage_profiles'));
     mgmt.setAttribute('data-profile', '__manage__');
     mgmt.innerHTML = `${li('settings',12)} ${esc(t('manage_profiles'))}`;
-    mgmt.onclick = () => { closeProfileDropdown({restore:true}); mobileSwitchPanel('profiles'); };
+    mgmt.onclick = () => {
+      // This is a navigation command, not a selection: close WITHOUT restoring
+      // focus (the opener chip/button can be hidden after the switch, e.g. on
+      // mobile) and land focus on the destination panel instead.
+      closeProfileDropdown();
+      mobileSwitchPanel('profiles');
+      _focusProfilesPanelDestination();
+    };
     dd.appendChild(mgmt);
   }
   // Sync titlebar label to the resolved active profile
@@ -6984,8 +6991,19 @@ window.addEventListener('resize',()=>{
 // The dropdown is a plain-div menu, so it previously had NO keyboard support:
 // opening it (click or Enter) left focus on the trigger and ArrowUp/Down did
 // nothing, forcing mouse-only selection. Mirror the session action menu pattern
-// (sessions.js _mountSessionActionMenu): options are focusable, arrow keys move
-// focus, Enter/Space select, Escape closes and returns focus to the trigger.
+// (sessions.js _mountSessionActionMenu): rows are focusable menuitems, arrow
+// keys move focus, Enter/Space activate, Escape closes and returns focus to the
+// trigger.
+
+function _focusProfilesPanelDestination(){
+  // After "Manage profiles" the opener may be hidden (mobile), so focus the
+  // destination panel heading instead of restoring focus to the trigger.
+  const panel=$('panelProfiles');
+  const head=panel && panel.querySelector('.panel-head');
+  if(!head) return;
+  if(head.getAttribute('tabindex')===null) head.setAttribute('tabindex','-1');
+  try{head.focus({preventScroll:true});}catch(_){head.focus();}
+}
 
 function _profileDropdownOptions(){
   const dd=$('profileDropdown');
@@ -7015,7 +7033,7 @@ function _focusProfileDropdownOption(){
   // re-focus the rebuilt row with the same data-profile instead of jumping
   // back to the active one.
   if(focusAttached) idx=items.findIndex(o=>o.getAttribute('data-profile')===_profileDropdownFocusedName);
-  if(idx<0) idx=items.findIndex(o=>o.getAttribute('aria-selected')==='true');
+  if(idx<0) idx=items.findIndex(o=>o.getAttribute('aria-current')==='true');
   if(idx<0) idx=0;
   const target=items[idx];
   if(target && target!==fe){

--- a/static/panels.js
+++ b/static/panels.js
@@ -7046,10 +7046,19 @@ function _focusProfileDropdownOption(){
 function _profileDropdownKeydownHandler(e){
   const dd=$('profileDropdown');
   if(!dd || !dd.classList.contains('open')) return;
-  // Scope the handler to the menu: once focus has left the listbox (e.g. Tab),
-  // Arrow/Home/End/Enter/Escape must keep working in the rest of the app, not
-  // be hijacked by an open menu the user has moved away from.
-  if(dd.contains(document.activeElement)===false) return;
+  // Menu-button contract: Tab / Shift+Tab moves focus out of the menu and
+  // dismisses it. Do NOT preventDefault (the native Tab must advance focus),
+  // do not restore focus to the trigger — the browser already moved it — and
+  // close deferred so the refresh-preservation logic cannot mistake this for a
+  // real focus exit.
+  if(e.key==='Tab' && dd.contains(document.activeElement)){
+    setTimeout(()=>{ closeProfileDropdown(); },0);
+    return;
+  }
+  // Scope the rest of the handler to the menu: once focus has left it by any
+  // non-Tab path, Arrow/Home/End/Enter/Escape must keep working in the rest of
+  // the app, not be hijacked by an open menu the user has moved away from.
+  if(dd.contains(document.activeElement)===false || document.activeElement===null) return;
   const items=_profileDropdownOptions();
   if(e.key==='Escape'){
     e.preventDefault();

--- a/static/style.css
+++ b/static/style.css
@@ -3386,6 +3386,7 @@
 .profile-opt{padding:10px 14px;cursor:pointer;transition:background .12s;}
 .profile-opt:hover{background:rgba(255,255,255,.07);}
 .profile-opt.active{background:var(--accent-bg);}
+.profile-opt:focus-visible{outline:2px solid var(--focus-ring);outline-offset:-2px;border-radius:4px;}
 .profile-opt-name{font-size:13px;color:var(--text);font-weight:500;}
 .profile-opt-meta{font-size:11px;color:var(--muted);margin-top:2px;}
 .profile-opt-badge{display:inline-block;width:7px;height:7px;border-radius:50%;margin-right:5px;vertical-align:middle;}

--- a/tests/test_profile_dropdown_fast_open.py
+++ b/tests/test_profile_dropdown_fast_open.py
@@ -76,7 +76,7 @@ def test_profile_dropdown_uses_shared_fetch_promise_and_validated_local_storage_
 
 
 def test_profile_dropdown_closing_invalidates_inflight_refresh():
-    close_body = _function_body(PANELS_JS, "function closeProfileDropdown() {")
+    close_body = _function_body(PANELS_JS, "function closeProfileDropdown(opts) {")
     assert "_profileDropdownOpenGeneration++;" in close_body
 
     toggle_body = _function_body(PANELS_JS, "function toggleProfileDropdown(e) {")
@@ -105,7 +105,10 @@ def test_poisoned_profile_cache_opens_then_switches_after_fresh_refresh():
         ],
         _function_body(PANELS_JS, "function renderProfileDropdown(data) {"),
         _function_body(PANELS_JS, "function toggleProfileDropdown(e) {"),
-        _function_body(PANELS_JS, "function closeProfileDropdown() {"),
+        _function_body(PANELS_JS, "function closeProfileDropdown(opts) {"),
+        _function_body(PANELS_JS, "function _profileDropdownOptions(){"),
+        _function_body(PANELS_JS, "function _focusProfileDropdownOption(){"),
+        _function_body(PANELS_JS, "function _profileDropdownKeydownHandler(e){"),
     ]
     script = textwrap.dedent(
         f"""
@@ -129,7 +132,9 @@ def test_poisoned_profile_cache_opens_then_switches_after_fresh_refresh():
             this.style = {{}};
             this.onclick = null;
             this.textContent = '';
+            this.isConnected = true;
             this._innerHTML = '';
+            this._attrs = {{}};
           }}
           set innerHTML(value) {{
             this._innerHTML = String(value || '');
@@ -137,6 +142,14 @@ def test_poisoned_profile_cache_opens_then_switches_after_fresh_refresh():
           }}
           get innerHTML() {{ return this._innerHTML; }}
           appendChild(child) {{ this.children.push(child); return child; }}
+          setAttribute(key, value) {{ this._attrs[key] = String(value); }}
+          getAttribute(key) {{ return this._attrs[key] !== undefined ? this._attrs[key] : null; }}
+          querySelectorAll(selector) {{
+            if (selector === '.profile-opt') return this.children.filter((child) => String(child.className).split(/\\s+/).includes('profile-opt'));
+            return [];
+          }}
+          contains(child) {{ return child === this || !!this.children.find((c) => typeof c.contains === 'function' && c.contains(child)); }}
+          focus() {{ document.activeElement = this; }}
         }}
         const elements = new Map();
         for (const id of ['profileDropdown', 'profileChip', 'titlebarProfileBtn', 'titlebarProfileLabel']) {{

--- a/tests/test_profile_dropdown_keyboard_navigation.py
+++ b/tests/test_profile_dropdown_keyboard_navigation.py
@@ -1,0 +1,279 @@
+"""
+Keyboard accessibility guards for the profile dropdown menu.
+
+User-visible failure: the composer/titlebar profile dropdown was a plain-div
+menu with no keyboard support — opening it (click or Enter) left focus on the
+trigger button, ArrowUp/ArrowDown did nothing, and there was no way to select a
+profile without a mouse. This pins the listbox contract (roles, tabindex,
+aria-selected), the arrow/Home/End/Enter/Escape key handler, focus-on-open, and
+focus-restore-on-close.
+"""
+import json
+import subprocess
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+PANELS_JS = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+INDEX_HTML = (REPO_ROOT / "static" / "index.html").read_text(encoding="utf-8")
+STYLE_CSS = (REPO_ROOT / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, marker: str) -> str:
+    start = src.index(marker)
+    depth = 0
+    opened = False
+    for idx, ch in enumerate(src[start:], start):
+        if ch == "{":
+            depth += 1
+            opened = True
+        elif ch == "}":
+            depth -= 1
+            if opened and depth == 0:
+                return src[start : idx + 1]
+    raise AssertionError(f"Could not extract function body for {marker}")
+
+
+# ── Source-level guards (no node required) ───────────────────────────────────
+
+
+def test_render_augments_profile_options_with_listbox_aria():
+    body = _function_body(PANELS_JS, "function renderProfileDropdown(data) {")
+    assert "setAttribute('role','listbox')" in body, "menu container must be a listbox"
+    assert "setAttribute('aria-label'," in body, "listbox needs an accessible name"
+    assert "opt.setAttribute('role','option')" in body, "options must be role=option"
+    assert "opt.setAttribute('tabindex','-1')" in body, "options must be programmatically focusable"
+    assert "opt.setAttribute('aria-selected'" in body, "options must expose selection state"
+    assert "_focusProfileDropdownOption();" in body, "focus must move into the menu on render"
+
+
+def test_keydown_handler_moves_and_selects_with_keys():
+    assert "_profileDropdownKeydownHandler" in PANELS_JS
+    body = _function_body(PANELS_JS, "function _profileDropdownKeydownHandler(e){")
+    for branch in ("'Escape'", "'ArrowDown'", "'ArrowUp'", "'Home'", "'End'", "'Enter'||e.key===' '"):
+        assert branch in body, f"keydown handler must handle {branch}"
+    assert "closeProfileDropdown({restore:true});" in body, "Escape must close and restore focus"
+    assert "items[current].click();" in body, "Enter/Space must activate the focused option"
+    assert "current>=0" in body, "Enter/Space must require focus inside the menu"
+
+
+def test_focus_restore_only_on_keyboard_requested_close():
+    body = _function_body(PANELS_JS, "function closeProfileDropdown(opts) {")
+    assert "const restore = !!(opts && opts.restore === true);" in body, "focus restore must be opt-in"
+    assert "dd.contains(document.activeElement)" in body, "restore must not steal focus from outside the menu"
+
+
+def test_keydown_handler_registered_and_triggers_open_on_arrow():
+    assert "document.addEventListener('keydown', _profileDropdownKeydownHandler);" in PANELS_JS
+    body = PANELS_JS[PANELS_JS.index("['profileChip','titlebarProfileBtn'].forEach(id=>{") :]
+    assert "toggleProfileDropdown(e);" in body
+    assert "e.key!=='ArrowDown' && e.key!=='ArrowUp'" in body
+
+
+def test_triggers_declare_listbox_relationship_in_html():
+    assert 'aria-haspopup="listbox"' in INDEX_HTML, "titlebar/composer triggers must declare the popup"
+    assert 'aria-controls="profileDropdown"' in INDEX_HTML
+    assert INDEX_HTML.count('aria-haspopup="listbox"') >= 2
+
+
+def test_focus_ring_stylesheet_for_menu_rows():
+    assert ".profile-opt:focus-visible" in STYLE_CSS
+
+
+# ── Behavioral guards (node execution of the real source) ─────────────────────
+
+
+def _dropdown_module_snippets():
+    return [
+        PANELS_JS[
+            PANELS_JS.index("let _profilesCache = null;")
+            : PANELS_JS.index("function _openProfileSwitchSessionBrowser(){")
+        ],
+    ]
+
+
+def test_keyboard_can_open_navigate_select_escape():
+    snippets = _dropdown_module_snippets()
+    script = textwrap.dedent(
+        f"""
+        const assert = require('assert');
+        const snippets = {json.dumps(snippets)};
+
+        class ClassList {{
+          constructor() {{ this.values = new Set(); }}
+          add(name) {{ this.values.add(name); }}
+          remove(name) {{ this.values.delete(name); }}
+          contains(name) {{ return this.values.has(name); }}
+        }}
+        class Element {{
+          constructor(tag, id) {{
+            this.tagName = tag;
+            this.id = id || '';
+            this.children = [];
+            this.className = '';
+            this.classList = new ClassList();
+            this.dataset = {{}};
+            this.style = {{}};
+            this.onclick = null;
+            this.textContent = '';
+            this.isConnected = true;
+            this._innerHTML = '';
+            this._attrs = {{}};
+            this._keydowns = [];
+          }}
+          set innerHTML(value) {{
+            this._innerHTML = String(value || '');
+            if (this._innerHTML === '') this.children = [];
+          }}
+          get innerHTML() {{ return this._innerHTML; }}
+          appendChild(child) {{ this.children.push(child); return child; }}
+          setAttribute(key, value) {{ this._attrs[key] = String(value); }}
+          getAttribute(key) {{ return this._attrs[key] !== undefined ? this._attrs[key] : null; }}
+          addEventListener(type, fn) {{ if (type === 'keydown') this._keydowns.push(fn); }}
+          querySelectorAll(selector) {{
+            if (selector === '.profile-opt') return this.children.filter((child) => String(child.className).split(/\\s+/).includes('profile-opt'));
+            return [];
+          }}
+          contains(child) {{ return child === this || !!this.children.find((c) => typeof c.contains === 'function' && c.contains(child)); }}
+          focus() {{ document.activeElement = this; }}
+          click() {{ return typeof this.onclick === 'function' ? this.onclick() : undefined; }}
+        }}
+        const elements = new Map();
+        for (const id of ['profileDropdown', 'profileChip', 'titlebarProfileBtn', 'titlebarProfileLabel']) {{
+          elements.set(id, new Element('div', id));
+        }}
+        globalThis.document = {{
+          hidden: false,
+          activeElement: null,
+          createElement: (tag) => new Element(tag),
+          getElementById: (id) => elements.get(id) || null,
+          addEventListener: (type, fn) => {{ if (type !== 'keydown') return; (document._keydowns || (document._keydowns = [])).push(fn); }},
+          _keydowns: [],
+        }};
+        globalThis.window = {{ addEventListener: () => {{}} }};
+        const store = new Map();
+        globalThis.localStorage = {{
+          getItem: (key) => store.has(key) ? store.get(key) : null,
+          setItem: (key, value) => store.set(key, String(value)),
+          removeItem: (key) => store.delete(key),
+        }};
+        globalThis.$ = (id) => elements.get(id) || null;
+        globalThis.S = {{ activeProfile: 'default' }};
+        globalThis.t = (key, n) => key === 'profile_skill_count' ? `${{n}} skills` : key;
+        globalThis.esc = (value) => String(value == null ? '' : value)
+          .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+          .replace(/\"/g, '&quot;').replace(/'/g, '&#39;');
+        globalThis.li = () => '';
+        globalThis.closeWsDropdown = () => {{}};
+        globalThis.closeModelDropdown = () => {{}};
+        globalThis._positionProfileDropdown = () => {{}};
+        globalThis.showToast = () => {{}};
+        globalThis.mobileSwitchPanel = () => {{}};
+        let switchedTo = null;
+        globalThis.switchToProfile = async (name) => {{ switchedTo = name; S.activeProfile = name; }};
+        const multiProfileResponse = {{
+          active: 'default',
+          single_profile_mode: false,
+          profiles: [
+            {{ name: 'default', visible: true, is_default: true }},
+            {{ name: 'other', visible: true }},
+          ],
+        }};
+        globalThis.api = () => Promise.resolve(multiProfileResponse);
+
+        // Export a test API from INSIDE the eval: the snippet's `let` bindings
+        // (e.g. _profilesCache) are scoped to the eval, so the runner must reach
+        // them through a closure created in the same eval, not through globals.
+        eval(snippets.join(String.fromCharCode(10)) + String.fromCharCode(10) + `;globalThis.__kbTest={{
+          reset() {{
+            _profilesCache = null;
+            _profileDropdownFetchPromise = null;
+            _profileDropdownCacheLoadedFromStorage = false;
+            _profileDropdownOpenGeneration = 0;
+            switchedTo = null;
+            S.activeProfile = 'default';
+            const dd = document.getElementById('profileDropdown');
+            dd.children = [];
+            dd.innerHTML = '';
+            dd.classList.remove('open');
+          }},
+          seedCache(data) {{ _profilesCache = data; }},
+          toggle(triggerId) {{ toggleProfileDropdown({{ currentTarget: document.getElementById(triggerId) }}); }},
+          isOpen() {{ return document.getElementById('profileDropdown').classList.contains('open'); }},
+          options() {{ return document.getElementById('profileDropdown').querySelectorAll('.profile-opt'); }},
+          active() {{ return document.activeElement; }},
+          chipExpanded() {{ return document.getElementById('profileChip').getAttribute('aria-expanded'); }},
+          dispatchKey(key) {{
+            const ev = {{ key, preventDefault() {{}}, stopPropagation() {{}} }};
+            document._keydowns.forEach((fn) => fn(ev));
+          }},
+          triggerKeydown(triggerId, key) {{
+            document.getElementById(triggerId)._keydowns.forEach((fn) => fn({{ key, preventDefault() {{}} }}));
+          }},
+          switched() {{ return switchedTo; }},
+        }};`);
+        if (document._keydowns.length !== 1) throw new Error('keydown handler must be registered exactly once');
+
+        async function runOpenNavigationEnter() {{
+          __kbTest.reset();
+          __kbTest.seedCache(multiProfileResponse);
+          __kbTest.toggle('profileChip');
+          assert.strictEqual(__kbTest.isOpen(), true, 'dropdown should open');
+          const items = __kbTest.options();
+          assert.strictEqual(items.length, 3, 'two profiles + manage row should be rendered');
+          assert.strictEqual(__kbTest.active(), items[0], 'focus should land on the active profile option on open');
+          assert.strictEqual(items[0].getAttribute('aria-selected'), 'true');
+          assert.strictEqual(__kbTest.chipExpanded(), 'true');
+
+          __kbTest.dispatchKey('ArrowDown');
+          assert.strictEqual(__kbTest.active(), items[1], 'ArrowDown moves to the next profile');
+          __kbTest.dispatchKey('ArrowDown');
+          assert.strictEqual(__kbTest.active(), items[2], 'ArrowDown wraps to manage option');
+          __kbTest.dispatchKey('End');
+          assert.strictEqual(__kbTest.active(), items[2], 'End should go to the last option');
+          __kbTest.dispatchKey('Home');
+          assert.strictEqual(__kbTest.active(), items[0], 'Home should go to the first option');
+          __kbTest.dispatchKey('ArrowUp');
+          assert.strictEqual(__kbTest.active(), items[2], 'ArrowUp wraps backwards');
+
+          // Enter on the 'other' profile selects it, closes the menu, and restores focus.
+          __kbTest.dispatchKey('ArrowUp'); // items[1]
+          assert.strictEqual(__kbTest.active(), items[1]);
+          __kbTest.dispatchKey('Enter');
+          await new Promise((resolve) => setImmediate(resolve));
+          assert.strictEqual(__kbTest.switched(), 'other', 'Enter on an option must switch profiles');
+          assert.strictEqual(__kbTest.isOpen(), false, 'selecting must close the dropdown');
+          assert.strictEqual(__kbTest.active(), document.getElementById('profileChip'), 'focus must return to the trigger after selection');
+          assert.strictEqual(__kbTest.chipExpanded(), 'false');
+        }}
+
+        async function runEscapeClosesAndRestores() {{
+          __kbTest.reset();
+          __kbTest.seedCache(multiProfileResponse);
+          __kbTest.toggle('profileChip');
+          assert.strictEqual(__kbTest.isOpen(), true);
+          assert.strictEqual(__kbTest.active(), __kbTest.options()[0]);
+          __kbTest.dispatchKey('Escape');
+          assert.strictEqual(__kbTest.isOpen(), false, 'Escape must close the dropdown');
+          assert.strictEqual(__kbTest.active(), document.getElementById('profileChip'), 'Escape must restore focus to the trigger');
+          assert.strictEqual(__kbTest.switched(), null, 'Escape must not switch profiles');
+        }}
+
+        async function runArrowDownOnTriggerOpens() {{
+          __kbTest.reset();
+          __kbTest.seedCache(multiProfileResponse);
+          // Menu closed: ArrowDown on the composer chip should open the menu.
+          assert.strictEqual(__kbTest.isOpen(), false);
+          __kbTest.triggerKeydown('profileChip', 'ArrowDown');
+          assert.strictEqual(__kbTest.isOpen(), true, 'ArrowDown on the trigger chip should open the menu');
+          assert.strictEqual(__kbTest.active(), __kbTest.options()[0], 'opening via arrow should focus the first option');
+        }}
+
+        (async () => {{
+          await runOpenNavigationEnter();
+          await runEscapeClosesAndRestores();
+          await runArrowDownOnTriggerOpens();
+        }})().catch((err) => {{ console.error(err && err.stack || err); process.exit(1); }});
+        """
+    )
+    subprocess.run(["node", "-e", script], cwd=REPO_ROOT, check=True, text=True, capture_output=True)

--- a/tests/test_profile_dropdown_keyboard_navigation.py
+++ b/tests/test_profile_dropdown_keyboard_navigation.py
@@ -75,6 +75,7 @@ def test_keyboard_can_open_navigate_select_escape_and_is_focus_scoped():
           setAttribute(key, value) {{ this._attrs[key] = String(value); }}
           getAttribute(key) {{ return this._attrs[key] !== undefined ? this._attrs[key] : null; }}
           addEventListener(type, fn) {{ if (type === 'keydown') this._keydowns.push(fn); }}
+          querySelector(selector) {{ return this._qs && this._qs[selector] ? this._qs[selector] : null; }}
           querySelectorAll(selector) {{
             if (selector === '.profile-opt') return this.children.filter((child) => String(child.className).split(/\\s+/).includes('profile-opt'));
             return [];
@@ -84,9 +85,15 @@ def test_keyboard_can_open_navigate_select_escape_and_is_focus_scoped():
           click() {{ return typeof this.onclick === 'function' ? this.onclick() : undefined; }}
         }}
         const elements = new Map();
-        for (const id of ['profileDropdown', 'profileChip', 'titlebarProfileBtn', 'titlebarProfileLabel', 'msg']) {{
+        for (const id of ['profileDropdown', 'profileChip', 'titlebarProfileBtn', 'titlebarProfileLabel', 'msg', 'panelProfiles', 'panelProfilesHead']) {{
           elements.set(id, new Element('div', id));
         }}
+        // Mirror static/index.html: the triggers declare a menu popup.
+        elements.get('profileChip').setAttribute('aria-haspopup', 'menu');
+        elements.get('titlebarProfileBtn').setAttribute('aria-haspopup', 'menu');
+        // Profiles panel with its heading, for the Manage-activation case.
+        elements.get('panelProfiles').appendChild(elements.get('panelProfilesHead'));
+        elements.get('panelProfiles')._qs = {{ '.panel-head': elements.get('panelProfilesHead') }};
         globalThis.document = {{
           hidden: false,
           activeElement: null,
@@ -171,17 +178,21 @@ def test_keyboard_can_open_navigate_select_escape_and_is_focus_scoped():
           __kbTest.seedCache(multiProfileResponse);
           __kbTest.toggle('profileChip');
           assert.strictEqual(__kbTest.isOpen(), true, 'dropdown should open');
-          assert.strictEqual(__kbTest.ddRole(), 'listbox', 'menu container must be a listbox');
+          assert.strictEqual(__kbTest.ddRole(), 'menu', 'popup must use the menu contract (rows + Manage command)');
           const items = __kbTest.options();
           assert.strictEqual(items.length, 4, 'three profiles + manage row should be rendered');
-          // Listbox option contract, asserted on the live DOM.
+          // Menu contract, asserted on the live DOM: every row is a menuitem,
+          // the active profile is marked with aria-current, and nothing uses
+          // listbox option semantics.
           for (const o of items) {{
-            assert.strictEqual(o.getAttribute('role'), 'option');
+            assert.strictEqual(o.getAttribute('role'), 'menuitem');
             assert.strictEqual(o.getAttribute('tabindex'), '-1');
+            assert.strictEqual(o.getAttribute('aria-selected'), null, 'no listbox option semantics on menu rows');
           }}
-          assert.strictEqual(items[0].getAttribute('aria-selected'), 'true', 'active profile selected');
-          assert.strictEqual(items[1].getAttribute('aria-selected'), 'false');
+          assert.strictEqual(items[0].getAttribute('aria-current'), 'true', 'active profile marked aria-current');
+          assert.strictEqual(items[1].getAttribute('aria-current'), null);
           assert.strictEqual(items[0].getAttribute('data-profile'), 'default');
+          assert.strictEqual(document.getElementById('profileChip').getAttribute('aria-haspopup'), 'menu');
           assert.strictEqual(__kbTest.active(), items[0], 'focus should land on the active profile option on open');
           assert.strictEqual(__kbTest.chipExpanded(), 'true');
 
@@ -286,12 +297,31 @@ def test_keyboard_can_open_navigate_select_escape_and_is_focus_scoped():
           assert.strictEqual(items[1].getAttribute('data-profile'), 'alpha');
         }}
 
+        async function runManageRowActivation() {{
+          __kbTest.reset();
+          __kbTest.seedCache(multiProfileResponse);
+          __kbTest.toggle('profileChip');
+          let switchedPanel = null;
+          globalThis.mobileSwitchPanel = (name) => {{ switchedPanel = name; }};
+          const items = __kbTest.options();
+          __kbTest.dispatchKey('End');
+          assert.strictEqual(__kbTest.active(), items[items.length - 1], 'End lands on the Manage row');
+          assert.strictEqual(items[items.length - 1].getAttribute('data-profile'), '__manage__');
+          __kbTest.dispatchKey('Enter');
+          await new Promise((resolve) => setImmediate(resolve));
+          assert.strictEqual(switchedPanel, 'profiles', 'Enter on Manage must open the Profiles panel');
+          assert.strictEqual(__kbTest.isOpen(), false, 'menu must close');
+          assert.strictEqual(__kbTest.active(), document.getElementById('panelProfilesHead'),
+            'focus must land on the Profiles panel heading, not the (possibly hidden on mobile) opener');
+        }}
+
         (async () => {{
           await runOpenNavigationEnter();
           await runEscapeClosesAndRestores();
           await runArrowDownOnTriggerOpens();
           await runHandlerInertWhenFocusLeftMenu();
           await runRefreshPreservesInProgressSelection();
+          await runManageRowActivation();
         }})().catch((err) => {{ console.error(err && err.stack || err); process.exit(1); }});
         """
     )

--- a/tests/test_profile_dropdown_keyboard_navigation.py
+++ b/tests/test_profile_dropdown_keyboard_navigation.py
@@ -5,8 +5,15 @@ User-visible failure: the composer/titlebar profile dropdown was a plain-div
 menu with no keyboard support — opening it (click or Enter) left focus on the
 trigger button, ArrowUp/ArrowDown did nothing, and there was no way to select a
 profile without a mouse. This pins the listbox contract (roles, tabindex,
-aria-selected), the arrow/Home/End/Enter/Escape key handler, focus-on-open, and
-focus-restore-on-close.
+aria-selected), the arrow/Home/End/Enter/Escape key handler, focus-on-open,
+focus-restore-on-close, and the two focus-lifecycle guarantees demanded by
+review: the handler only acts while focus is inside the menu, and a background
+refresh preserves an in-progress keyboard selection.
+
+All guards are behavioral: they execute the real dropdown module from
+static/panels.js in node under a minimal DOM shim and assert on observable
+state (focused element, aria attributes, open/close, switch target), never on
+source text.
 """
 import json
 import subprocess
@@ -15,72 +22,6 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent.resolve()
 PANELS_JS = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
-INDEX_HTML = (REPO_ROOT / "static" / "index.html").read_text(encoding="utf-8")
-STYLE_CSS = (REPO_ROOT / "static" / "style.css").read_text(encoding="utf-8")
-
-
-def _function_body(src: str, marker: str) -> str:
-    start = src.index(marker)
-    depth = 0
-    opened = False
-    for idx, ch in enumerate(src[start:], start):
-        if ch == "{":
-            depth += 1
-            opened = True
-        elif ch == "}":
-            depth -= 1
-            if opened and depth == 0:
-                return src[start : idx + 1]
-    raise AssertionError(f"Could not extract function body for {marker}")
-
-
-# ── Source-level guards (no node required) ───────────────────────────────────
-
-
-def test_render_augments_profile_options_with_listbox_aria():
-    body = _function_body(PANELS_JS, "function renderProfileDropdown(data) {")
-    assert "setAttribute('role','listbox')" in body, "menu container must be a listbox"
-    assert "setAttribute('aria-label'," in body, "listbox needs an accessible name"
-    assert "opt.setAttribute('role','option')" in body, "options must be role=option"
-    assert "opt.setAttribute('tabindex','-1')" in body, "options must be programmatically focusable"
-    assert "opt.setAttribute('aria-selected'" in body, "options must expose selection state"
-    assert "_focusProfileDropdownOption();" in body, "focus must move into the menu on render"
-
-
-def test_keydown_handler_moves_and_selects_with_keys():
-    assert "_profileDropdownKeydownHandler" in PANELS_JS
-    body = _function_body(PANELS_JS, "function _profileDropdownKeydownHandler(e){")
-    for branch in ("'Escape'", "'ArrowDown'", "'ArrowUp'", "'Home'", "'End'", "'Enter'||e.key===' '"):
-        assert branch in body, f"keydown handler must handle {branch}"
-    assert "closeProfileDropdown({restore:true});" in body, "Escape must close and restore focus"
-    assert "items[current].click();" in body, "Enter/Space must activate the focused option"
-    assert "current>=0" in body, "Enter/Space must require focus inside the menu"
-
-
-def test_focus_restore_only_on_keyboard_requested_close():
-    body = _function_body(PANELS_JS, "function closeProfileDropdown(opts) {")
-    assert "const restore = !!(opts && opts.restore === true);" in body, "focus restore must be opt-in"
-    assert "dd.contains(document.activeElement)" in body, "restore must not steal focus from outside the menu"
-
-
-def test_keydown_handler_registered_and_triggers_open_on_arrow():
-    assert "document.addEventListener('keydown', _profileDropdownKeydownHandler);" in PANELS_JS
-    body = PANELS_JS[PANELS_JS.index("['profileChip','titlebarProfileBtn'].forEach(id=>{") :]
-    assert "toggleProfileDropdown(e);" in body
-    assert "e.key!=='ArrowDown' && e.key!=='ArrowUp'" in body
-
-
-def test_triggers_declare_listbox_relationship_in_html():
-    assert 'aria-haspopup="listbox"' in INDEX_HTML, "titlebar/composer triggers must declare the popup"
-    assert 'aria-controls="profileDropdown"' in INDEX_HTML
-    assert INDEX_HTML.count('aria-haspopup="listbox"') >= 2
-
-
-def test_focus_ring_stylesheet_for_menu_rows():
-    assert ".profile-opt:focus-visible" in STYLE_CSS
-
-
-# ── Behavioral guards (node execution of the real source) ─────────────────────
 
 
 def _dropdown_module_snippets():
@@ -92,7 +33,7 @@ def _dropdown_module_snippets():
     ]
 
 
-def test_keyboard_can_open_navigate_select_escape():
+def test_keyboard_can_open_navigate_select_escape_and_is_focus_scoped():
     snippets = _dropdown_module_snippets()
     script = textwrap.dedent(
         f"""
@@ -123,7 +64,11 @@ def test_keyboard_can_open_navigate_select_escape():
           }}
           set innerHTML(value) {{
             this._innerHTML = String(value || '');
-            if (this._innerHTML === '') this.children = [];
+            if (this._innerHTML === '') {{
+              // Mirror the DOM: clearing innerHTML detaches the old children.
+              this.children.forEach((c) => {{ c.isConnected = false; }});
+              this.children = [];
+            }}
           }}
           get innerHTML() {{ return this._innerHTML; }}
           appendChild(child) {{ this.children.push(child); return child; }}
@@ -139,7 +84,7 @@ def test_keyboard_can_open_navigate_select_escape():
           click() {{ return typeof this.onclick === 'function' ? this.onclick() : undefined; }}
         }}
         const elements = new Map();
-        for (const id of ['profileDropdown', 'profileChip', 'titlebarProfileBtn', 'titlebarProfileLabel']) {{
+        for (const id of ['profileDropdown', 'profileChip', 'titlebarProfileBtn', 'titlebarProfileLabel', 'msg']) {{
           elements.set(id, new Element('div', id));
         }}
         globalThis.document = {{
@@ -176,7 +121,8 @@ def test_keyboard_can_open_navigate_select_escape():
           single_profile_mode: false,
           profiles: [
             {{ name: 'default', visible: true, is_default: true }},
-            {{ name: 'other', visible: true }},
+            {{ name: 'alpha', visible: true }},
+            {{ name: 'beta', visible: true }},
           ],
         }};
         globalThis.api = () => Promise.resolve(multiProfileResponse);
@@ -190,8 +136,10 @@ def test_keyboard_can_open_navigate_select_escape():
             _profileDropdownFetchPromise = null;
             _profileDropdownCacheLoadedFromStorage = false;
             _profileDropdownOpenGeneration = 0;
+            _profileDropdownFocusedName = null;
             switchedTo = null;
             S.activeProfile = 'default';
+            document.activeElement = null;
             const dd = document.getElementById('profileDropdown');
             dd.children = [];
             dd.innerHTML = '';
@@ -199,13 +147,17 @@ def test_keyboard_can_open_navigate_select_escape():
           }},
           seedCache(data) {{ _profilesCache = data; }},
           toggle(triggerId) {{ toggleProfileDropdown({{ currentTarget: document.getElementById(triggerId) }}); }},
+          render(data) {{ renderProfileDropdown(data); }},
           isOpen() {{ return document.getElementById('profileDropdown').classList.contains('open'); }},
           options() {{ return document.getElementById('profileDropdown').querySelectorAll('.profile-opt'); }},
+          ddRole() {{ return document.getElementById('profileDropdown').getAttribute('role'); }},
           active() {{ return document.activeElement; }},
           chipExpanded() {{ return document.getElementById('profileChip').getAttribute('aria-expanded'); }},
+          focusOn(id) {{ document.activeElement = document.getElementById(id); }},
           dispatchKey(key) {{
-            const ev = {{ key, preventDefault() {{}}, stopPropagation() {{}} }};
+            const ev = {{ key, preventDefault() {{ this._pd = true; }}, stopPropagation() {{}} }};
             document._keydowns.forEach((fn) => fn(ev));
+            return ev;
           }},
           triggerKeydown(triggerId, key) {{
             document.getElementById(triggerId)._keydowns.forEach((fn) => fn({{ key, preventDefault() {{}} }}));
@@ -219,29 +171,40 @@ def test_keyboard_can_open_navigate_select_escape():
           __kbTest.seedCache(multiProfileResponse);
           __kbTest.toggle('profileChip');
           assert.strictEqual(__kbTest.isOpen(), true, 'dropdown should open');
+          assert.strictEqual(__kbTest.ddRole(), 'listbox', 'menu container must be a listbox');
           const items = __kbTest.options();
-          assert.strictEqual(items.length, 3, 'two profiles + manage row should be rendered');
+          assert.strictEqual(items.length, 4, 'three profiles + manage row should be rendered');
+          // Listbox option contract, asserted on the live DOM.
+          for (const o of items) {{
+            assert.strictEqual(o.getAttribute('role'), 'option');
+            assert.strictEqual(o.getAttribute('tabindex'), '-1');
+          }}
+          assert.strictEqual(items[0].getAttribute('aria-selected'), 'true', 'active profile selected');
+          assert.strictEqual(items[1].getAttribute('aria-selected'), 'false');
+          assert.strictEqual(items[0].getAttribute('data-profile'), 'default');
           assert.strictEqual(__kbTest.active(), items[0], 'focus should land on the active profile option on open');
-          assert.strictEqual(items[0].getAttribute('aria-selected'), 'true');
           assert.strictEqual(__kbTest.chipExpanded(), 'true');
 
           __kbTest.dispatchKey('ArrowDown');
           assert.strictEqual(__kbTest.active(), items[1], 'ArrowDown moves to the next profile');
           __kbTest.dispatchKey('ArrowDown');
-          assert.strictEqual(__kbTest.active(), items[2], 'ArrowDown wraps to manage option');
+          assert.strictEqual(__kbTest.active(), items[2], 'ArrowDown moves again');
+          __kbTest.dispatchKey('ArrowDown');
+          assert.strictEqual(__kbTest.active(), items[3], 'ArrowDown wraps to manage option');
           __kbTest.dispatchKey('End');
-          assert.strictEqual(__kbTest.active(), items[2], 'End should go to the last option');
+          assert.strictEqual(__kbTest.active(), items[3], 'End should go to the last option');
           __kbTest.dispatchKey('Home');
           assert.strictEqual(__kbTest.active(), items[0], 'Home should go to the first option');
           __kbTest.dispatchKey('ArrowUp');
-          assert.strictEqual(__kbTest.active(), items[2], 'ArrowUp wraps backwards');
+          assert.strictEqual(__kbTest.active(), items[3], 'ArrowUp wraps backwards');
+          __kbTest.dispatchKey('ArrowUp');
+          __kbTest.dispatchKey('ArrowUp');
+          assert.strictEqual(__kbTest.active(), items[1], 'ArrowUp lands on alpha');
 
-          // Enter on the 'other' profile selects it, closes the menu, and restores focus.
-          __kbTest.dispatchKey('ArrowUp'); // items[1]
-          assert.strictEqual(__kbTest.active(), items[1]);
+          // Enter on the 'alpha' profile selects it, closes the menu, and restores focus.
           __kbTest.dispatchKey('Enter');
           await new Promise((resolve) => setImmediate(resolve));
-          assert.strictEqual(__kbTest.switched(), 'other', 'Enter on an option must switch profiles');
+          assert.strictEqual(__kbTest.switched(), 'alpha', 'Enter on an option must switch profiles');
           assert.strictEqual(__kbTest.isOpen(), false, 'selecting must close the dropdown');
           assert.strictEqual(__kbTest.active(), document.getElementById('profileChip'), 'focus must return to the trigger after selection');
           assert.strictEqual(__kbTest.chipExpanded(), 'false');
@@ -269,10 +232,66 @@ def test_keyboard_can_open_navigate_select_escape():
           assert.strictEqual(__kbTest.active(), __kbTest.options()[0], 'opening via arrow should focus the first option');
         }}
 
+        async function runHandlerInertWhenFocusLeftMenu() {{
+          __kbTest.reset();
+          __kbTest.seedCache(multiProfileResponse);
+          __kbTest.toggle('profileChip');
+          assert.strictEqual(__kbTest.isOpen(), true);
+          // Simulate Tab leaving the listbox: focus moves to an unrelated
+          // control (the composer textarea).
+          __kbTest.focusOn('msg');
+          const evDown = __kbTest.dispatchKey('ArrowDown');
+          assert.ok(!evDown._pd, 'ArrowDown outside the menu must not be swallowed');
+          assert.strictEqual(__kbTest.active(), document.getElementById('msg'), 'focus must not move while outside the menu');
+          const evEnter = __kbTest.dispatchKey('Enter');
+          assert.ok(!evEnter._pd, 'Enter outside the menu must not be swallowed');
+          assert.strictEqual(__kbTest.switched(), null, 'Enter outside the menu must not switch profiles');
+          const evEsc = __kbTest.dispatchKey('Escape');
+          assert.ok(!evEsc._pd, 'Escape outside the menu must not be swallowed');
+          assert.strictEqual(__kbTest.isOpen(), true, 'menu stays open (click-outside still dismisses it); keys pass through to the app');
+          // And a background refresh while focus is elsewhere must not yank it
+          // back into the menu.
+          __kbTest.render({{
+            active: 'default',
+            single_profile_mode: false,
+            profiles: [
+              {{ name: 'default', visible: true, is_default: true, model: 'openai/gpt-5.4-mini' }},
+              {{ name: 'alpha', visible: true, model: 'google/gemini-2.5-pro' }},
+              {{ name: 'beta', visible: true, model: 'anthropic/claude-sonnet-4-6' }},
+            ],
+          }});
+          assert.strictEqual(__kbTest.active(), document.getElementById('msg'), 'refresh must not steal focus from the composer');
+        }}
+
+        async function runRefreshPreservesInProgressSelection() {{
+          __kbTest.reset();
+          __kbTest.seedCache(multiProfileResponse);
+          __kbTest.toggle('profileChip');
+          __kbTest.dispatchKey('ArrowDown'); // alpha holds focus
+          assert.strictEqual(__kbTest.active(), __kbTest.options()[1]);
+          // Background /api/profiles refresh re-renders the menu (same names,
+          // different model text) — the in-progress selection must survive.
+          __kbTest.render({{
+            active: 'default',
+            single_profile_mode: false,
+            profiles: [
+              {{ name: 'default', visible: true, is_default: true, model: 'openai/gpt-5.4-mini' }},
+              {{ name: 'alpha', visible: true, model: 'google/gemini-2.5-pro' }},
+              {{ name: 'beta', visible: true, model: 'anthropic/claude-sonnet-4-6' }},
+            ],
+          }});
+          assert.strictEqual(__kbTest.isOpen(), true, 'refresh keeps the menu open');
+          const items = __kbTest.options();
+          assert.strictEqual(__kbTest.active(), items[1], 'focus must stay on alpha after the refresh rebuild');
+          assert.strictEqual(items[1].getAttribute('data-profile'), 'alpha');
+        }}
+
         (async () => {{
           await runOpenNavigationEnter();
           await runEscapeClosesAndRestores();
           await runArrowDownOnTriggerOpens();
+          await runHandlerInertWhenFocusLeftMenu();
+          await runRefreshPreservesInProgressSelection();
         }})().catch((err) => {{ console.error(err && err.stack || err); process.exit(1); }});
         """
     )

--- a/tests/test_profile_dropdown_keyboard_navigation.py
+++ b/tests/test_profile_dropdown_keyboard_navigation.py
@@ -161,8 +161,8 @@ def test_keyboard_can_open_navigate_select_escape_and_is_focus_scoped():
           active() {{ return document.activeElement; }},
           chipExpanded() {{ return document.getElementById('profileChip').getAttribute('aria-expanded'); }},
           focusOn(id) {{ document.activeElement = document.getElementById(id); }},
-          dispatchKey(key) {{
-            const ev = {{ key, preventDefault() {{ this._pd = true; }}, stopPropagation() {{}} }};
+          dispatchKey(key, opts) {{
+            const ev = Object.assign({{ key, preventDefault() {{ this._pd = true; }}, stopPropagation() {{}} }}, opts || {{}});
             document._keydowns.forEach((fn) => fn(ev));
             return ev;
           }},
@@ -315,6 +315,37 @@ def test_keyboard_can_open_navigate_select_escape_and_is_focus_scoped():
             'focus must land on the Profiles panel heading, not the (possibly hidden on mobile) opener');
         }}
 
+        async function runTabDismissal() {{
+          // Menu-button contract: Tab / Shift+Tab moves focus out of the menu
+          // and dismisses it — from the first AND last menuitem. Native Tab is
+          // not prevented; focus stays on the outside control; both triggers
+          // report aria-expanded=false; no profile switch occurs.
+          const cases = [
+            {{ from: 'first', key: 'Tab', opts: {{}} }},
+            {{ from: 'first', key: 'Tab', opts: {{ shiftKey: true }} }},
+            {{ from: 'last', key: 'Tab', opts: {{}} }},
+            {{ from: 'last', key: 'Tab', opts: {{ shiftKey: true }} }},
+          ];
+          for (const c of cases) {{
+            __kbTest.reset();
+            __kbTest.seedCache(multiProfileResponse);
+            __kbTest.toggle('profileChip');
+            const items = __kbTest.options();
+            if (c.from === 'last') __kbTest.dispatchKey('End');
+            assert.strictEqual(__kbTest.active(), c.from === 'first' ? items[0] : items[items.length - 1], `start on ${{c.from}} menuitem`);
+            __kbTest.dispatchKey(c.key, c.opts);
+            // Mirror the browser: the native Tab advance lands focus outside
+            // the menu; the deferred close runs after it.
+            __kbTest.focusOn('msg');
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            assert.strictEqual(__kbTest.isOpen(), false, `Tab (${{c.from}}, shift=${{!!c.opts.shiftKey}}) must dismiss the menu`);
+            assert.strictEqual(__kbTest.active(), document.getElementById('msg'), 'focus stays on the outside control');
+            assert.strictEqual(__kbTest.chipExpanded(), 'false');
+            assert.strictEqual(document.getElementById('titlebarProfileBtn').getAttribute('aria-expanded'), 'false');
+            assert.strictEqual(__kbTest.switched(), null, 'no profile switch on Tab dismissal');
+          }}
+        }}
+
         (async () => {{
           await runOpenNavigationEnter();
           await runEscapeClosesAndRestores();
@@ -322,6 +353,7 @@ def test_keyboard_can_open_navigate_select_escape_and_is_focus_scoped():
           await runHandlerInertWhenFocusLeftMenu();
           await runRefreshPreservesInProgressSelection();
           await runManageRowActivation();
+          await runTabDismissal();
         }})().catch((err) => {{ console.error(err && err.stack || err); process.exit(1); }});
         """
     )


### PR DESCRIPTION
### Thinking Path
- Hermes WebUI aims for near-CLI parity in a browser, and heavy keyboard users drive it without a mouse (I use Vimium link hints to click the trigger).
- The profile dropdown is a plain-div menu rendered into `#profileDropdown` by `renderProfileDropdown()`; the two triggers (`#profileChip`, `#titlebarProfileBtn`) are real `<button>`s, but once the menu opened there was **no focus management at all**: options are divs without `tabindex`, no keydown handler exists, so ArrowUp/Down did nothing and Enter could not select a profile without a mouse.
- The repo already ships the exact pattern we need in `sessions.js` (`_mountSessionActionMenu`): focusable items, arrow/Home/End movement, Escape to close, focus restore to the trigger. This PR ports that pattern to the profile dropdown and uses the ARIA **menu-button contract** (`role="menu"`/`role="menuitem"`, `aria-current` on the active profile) — a listbox would be a semantic mislabel here because the popup also contains a navigation command, not just selectable values.
- Result: click (or Vimium-hint) the trigger once → focus lands in the menu → arrows move → Enter selects → Escape dismisses.

### What Changed
- `static/panels.js`
  - `renderProfileDropdown()`: container gets `role="menu"` + `aria-label`; each `.profile-opt` (profiles + Manage row) gets `role="menuitem"`, `tabindex="-1"`; the active profile gets `aria-current="true"`; every row carries `data-profile` for stable identity across re-renders. Manage is a navigation command, so it stays a menuitem (not an option) and its activation closes without focus-restore and focuses the Profiles panel heading (`_focusProfilesPanelDestination`).
  - `toggleProfileDropdown()`: opens the shell *before* rendering so focus-on-open works on both the cached and fresh-fetch paths.
  - New `_profileDropdownOptions()`, `_focusProfileDropdownOption()` (focus the active profile's option, else the first; preserves an in-progress selection across refresh by `data-profile`; never steals focus from unrelated controls), `_profileDropdownKeydownHandler(e)` (focus-scoped to the open menu: ArrowDown/ArrowUp/Home/End move focus, Enter/Space activate the focused option, Escape closes with focus restore, **Tab/Shift+Tab dismisses the menu**: native Tab is not prevented, focus is not restored, and the close is deferred with `setTimeout(0)` so the refresh-preservation logic cannot mistake the exit for a focus change).
  - `closeProfileDropdown(opts)`: new optional `{restore:true}` restores focus to the trigger only if focus was inside the menu (click-outside closes never steal focus); sets `aria-expanded="false"` on both triggers.
  - `_openProfileDropdownShell()`: sets `aria-expanded="true"` on the active trigger.
  - Trigger buttons: keydown on ArrowUp/Down when the menu is closed opens it.
- `static/index.html`: `aria-haspopup="menu"`, `aria-expanded="false"`, `aria-controls="profileDropdown"` on both triggers.
- `static/style.css`: `.profile-opt:focus-visible` outline (`var(--focus-ring)`) so keyboard focus is visible.
- `tests/test_profile_dropdown_keyboard_navigation.py` (new): a purely behavioral node harness that evals the real dropdown module and drives open → focus → ArrowDown/Home/End/ArrowUp → Enter (switches + closes + restores focus) → Escape (closes + restores + no switch) → ArrowDown-on-trigger-opens, plus the two focus-lifecycle guarantees below.
- `tests/test_profile_dropdown_fast_open.py`: harness Element shim extended (`setAttribute`/`getAttribute`/`querySelectorAll`/`contains`/`focus`) and the new helper functions added to the evaluated snippets.

### Why It Matters
- Profile switching is now usable without a mouse — for keyboard-first users, Vimium users, and screen-reader users. The dropdown matches the rest of the UI's keyboard model (session action menu) and the ARIA expectations of a menu button, so both dropdown locations (composer footer + titlebar) behave identically.
- No new dependencies, no build step, no framework — vanilla JS + CSS in the existing files, following the existing `sessions.js` pattern.

### Verification
- Final full-suite run on the branch head (`2d618a76`): **15,208 passed, 187 skipped, 3 failed**. All 3 failures reproduce identically on clean `origin/master` (environmental: `test_terminal_process_cleanup`, `test_tls_aware_probe` ×2 — they exercise PTY/TLS setup, not this change). An earlier run on the first commit showed 2 additional failures (`test_minimax_provider`, `test_static_asset_resolver` — neither touches this change) that pass on re-run and passed on the final runs.
- Target regression files: `./scripts/test.sh tests/test_profile_dropdown_keyboard_navigation.py tests/test_profile_dropdown_fast_open.py` → all pass on the latest commit (`2d618a76`).
- `node --check static/panels.js` clean; eslint runtime guard (`npm run lint:runtime`) does not flag the change.
- Behavioral coverage (node harness executing the real source) asserts on observable state only: focus lands on the active profile on open, arrows/Home/End navigate (with wrap), Enter switches + closes + restores trigger focus, Escape closes + restores + does not switch, ArrowDown on the trigger opens the menu, keys outside the menu are never swallowed (focus-scoped handler), a background refresh preserves the in-progress selection, and a refresh never steals focus from unrelated controls.
- Review feedback addressed in commit `c48d3d19`: focus-scoped key handler + refresh-safe selection, with source-presence test asserts replaced by purely behavioral ones. Maintainer feedback (menu contract, Manage focus) addressed in commit `a909ee7e`: popup is `role="menu"`/rows `role="menuitem"`/active marked `aria-current` (no listbox/`aria-selected` mixing), triggers declare `aria-haspopup="menu"`, and the Manage row closes without restore and focuses the Profiles panel heading afterwards. Maintainer follow-up (Tab dismissal) addressed in commit `2d618a76`: Tab/Shift+Tab closes the popup after the native focus advance (no preventDefault, no focus restore), both triggers report `aria-expanded="false"`, and focus leaving by other paths stays distinct from Tab dismissal.
- Before/after evidence: attached in the comment below (same isolated two-profile fixture, identical script: open menu → press ArrowDown). Before: focus stays on the trigger chip, ArrowDown inert. After: focus lands on the active option on open; ArrowDown moves to the next profile with the visible `--focus-ring` outline.

### Risks / Follow-ups
- The workspace dropdown (`#composerWsDropdown`) and model dropdown are sibling plain-div menus with the same no-keyboard gap; out of scope here to keep the PR to one logical change — a follow-up could apply the same handler.
- Focus now moves into the menu on open even for mouse clicks; this is the standard listbox behavior and matches the session action menu.
- The keydown handler is deliberately inert when focus leaves the menu by a non-Tab path (e.g. programmatic focus move): keys return to the app and the menu remains until click-outside or Tab. Tab/Shift+Tab itself dismisses the menu per the menu-button contract, kept distinct from the refresh-preservation cases. Enter/Space on the trigger still toggles the menu natively.

### Model Used
- deepseek/deepseek-v4-flash-0731 via OpenRouter, driven from a Hermes Agent session (profile `o`). AI used for implementation, tests, and this description.