### PR TITLE
Allow authenticated null-origin native requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ If an AI assistant is helping with install, reinstall, bootstrap, provider setup
 - Optional native OIDC login for WebUI sessions -- configure `webui_oidc.issuer`, `client_id`, `allow_claim`, and `allow_values` in `config.yaml`, or set the matching `HERMES_WEBUI_OIDC_*` environment variables. OIDC stays disabled until all four are present, and startup prints a warning if the config is partial.
 - Native OIDC stores the PKCE/state nonce flow in process memory. That works for the shipped single-process server, and it also works behind a load balancer when callbacks stay sticky to the same WebUI instance. Multi-instance deployments need session affinity, or the callback can land on a different process and fail state validation.
 - Signed HMAC HTTP-only cookie with 24h TTL
+- When authentication is enabled, unsafe browser requests require same-origin provenance plus a CSRF token bound to the current session. Native clients that send the exact opaque-origin value `Origin: null` without a Referer or explicit cross-site signal may skip host matching only while auth is enabled and the current session's CSRF token is present.
 - Minimal dark-themed login page at `/login`
 - Security headers on all responses (X-Content-Type-Options, X-Frame-Options, Referrer-Policy)
 - 20MB POST body size limit

--- a/api/routes.py
+++ b/api/routes.py
@@ -5711,7 +5711,13 @@ def _csrf_rejection_error(handler) -> str:
 
 def _check_csrf(handler) -> bool:
     """Reject cross-origin or tokenless authenticated browser unsafe requests."""
-    if not _check_same_origin_browser_request(handler):
+    origin = handler.headers.get("Origin", "")
+    opaque_null_origin = origin == "null" and not handler.headers.get("Referer")
+    if opaque_null_origin:
+        _clear_csrf_failure_reason(handler)
+        if handler.headers.get("Sec-Fetch-Site", "").strip().lower() == "cross-site":
+            return _set_csrf_failure_reason(handler, "origin_mismatch")
+    elif not _check_same_origin_browser_request(handler):
         return False
     if not _is_browser_unsafe_request(handler):
         return True  # non-browser clients (curl, MCP, agent) have no Origin/Referer
@@ -5719,6 +5725,8 @@ def _check_csrf(handler) -> bool:
     from api.auth import CSRF_HEADER_NAME, is_auth_enabled, parse_cookie, verify_csrf_token
 
     if not is_auth_enabled():
+        if opaque_null_origin:
+            return _set_csrf_failure_reason(handler, "origin_mismatch")
         return True
     cookie_val = parse_cookie(handler)
     submitted = handler.headers.get(CSRF_HEADER_NAME) or handler.headers.get("X-CSRF-Token")
@@ -18059,7 +18067,9 @@ def _read_json_request_body(handler, *, max_bytes: int = 4096) -> dict:
 def _handle_escape_authorize(handler, parsed, body: dict | None = None):
     if handler.command != "POST":
         return bad(handler, "method not allowed", 405)
-    if not handler.headers.get("Origin"):
+    if not handler.headers.get("Origin") or not _check_same_origin_browser_request(
+        handler, require_provenance=True
+    ):
         return bad(handler, "browser origin required", 403)
     if not _check_csrf(handler):
         return bad(handler, _csrf_rejection_error(handler), 403)

--- a/tests/test_cors_preflight_allowlist.py
+++ b/tests/test_cors_preflight_allowlist.py
@@ -56,6 +56,13 @@ class TestPreflightAllowOrigin:
             "Host": "127.0.0.1:8787",
         }) == ""
 
+    def test_null_origin_emits_no_allow_origin_header(self):
+        sent = _preflight_headers({
+            "Origin": "null",
+            "Host": "127.0.0.1:8787",
+        })
+        assert "Access-Control-Allow-Origin" not in sent
+
     def test_wildcard_never_returned(self):
         """Even a same-origin match echoes the Origin, never '*'."""
         result = _preflight({

--- a/tests/test_extension_sidecar_proxy.py
+++ b/tests/test_extension_sidecar_proxy.py
@@ -1,8 +1,11 @@
 """Focused tests for the extension sidecar proxy contract."""
 
 from types import SimpleNamespace
+import hashlib
+import hmac
 import io
 import json
+import time
 import urllib.request
 
 import pytest
@@ -484,6 +487,67 @@ def test_extension_sidecar_proxy_post_requires_browser_provenance(monkeypatch):
     assert json.loads(handler.body.decode("utf-8")) == {
         "error": "Cross-origin mismatch - check reverse proxy headers"
     }
+
+
+@pytest.mark.parametrize(
+    ("method", "body"),
+    (("GET", b""), ("POST", b'{"ping":"pong"}')),
+)
+def test_extension_sidecar_proxy_rejects_null_origin_before_resolution(
+    method, body, monkeypatch
+):
+    from api import auth, routes
+
+    raw_token = "x" * 64
+    auth._sessions[raw_token] = time.time() + 60
+    signature = hmac.new(
+        auth._signing_key(), raw_token.encode(), hashlib.sha256
+    ).hexdigest()
+    cookie = f"{raw_token}.{signature}"
+    csrf_token = auth.csrf_token_for_session(cookie)
+    monkeypatch.setattr(auth, "is_auth_enabled", lambda: True)
+
+    def fail_if_resolved(*_args, **_kwargs):
+        raise AssertionError("null-origin sidecar request reached proxy resolution")
+
+    monkeypatch.setattr(
+        "api.extensions.resolve_extension_sidecar_proxy_target",
+        fail_if_resolved,
+    )
+
+    try:
+        assert auth.verify_session(cookie)
+        assert csrf_token and auth.verify_csrf_token(cookie, csrf_token)
+
+        handler = FakeHandler(body)
+        handler.headers = {
+            "Origin": "null",
+            "Host": "webui.local",
+            "Cookie": f"{auth.COOKIE_NAME}={cookie}",
+            auth.CSRF_HEADER_NAME: csrf_token,
+        }
+        if method == "POST":
+            handler.headers.update({
+                "Content-Type": "application/json",
+                "Content-Length": str(len(body)),
+            })
+
+        route = routes.handle_get if method == "GET" else routes.handle_post
+        result = route(
+            handler,
+            SimpleNamespace(
+                path="/api/extensions/templates/sidecar/v1/ping",
+                query="",
+            ),
+        )
+
+        assert result is None
+        assert handler.status == 403
+        assert json.loads(handler.body.decode("utf-8")) == {
+            "error": "Cross-origin mismatch - check reverse proxy headers"
+        }
+    finally:
+        auth._sessions.pop(raw_token, None)
 
 
 def test_extension_sidecar_proxy_get_allows_same_origin_browser_request_without_csrf_token(monkeypatch):

--- a/tests/test_issue1909_csrf_token.py
+++ b/tests/test_issue1909_csrf_token.py
@@ -35,6 +35,19 @@ class _FakeHandler:
         pass
 
 
+def _post_logout(headers):
+    handler = _FakeHandler(
+        {
+            "Content-Length": "2",
+            "Content-Type": "application/json",
+            "Host": "127.0.0.1:8787",
+            **headers,
+        }
+    )
+    routes.handle_post(handler, SimpleNamespace(path="/api/auth/logout", query=""))
+    return handler
+
+
 def test_csrf_token_is_bound_to_auth_session():
     cookie_a = _signed_cookie("a" * 64)
     cookie_b = _signed_cookie("b" * 64)
@@ -67,6 +80,142 @@ def test_authenticated_same_origin_browser_post_requires_session_csrf_token(monk
         assert routes._check_csrf(_FakeHandler(headers_with_token))
     finally:
         auth._sessions.pop("c" * 64, None)
+
+
+def test_authenticated_null_origin_logout_accepts_valid_session_csrf_token(monkeypatch):
+    cookie = _signed_cookie("n" * 64)
+    token = auth.csrf_token_for_session(cookie)
+    monkeypatch.setattr(auth, "is_auth_enabled", lambda: True)
+    try:
+        handler = _post_logout(
+            {
+                "Origin": "null",
+                "Cookie": f"{auth.COOKIE_NAME}={cookie}",
+                auth.CSRF_HEADER_NAME: token,
+            }
+        )
+
+        assert handler.status == 200
+        assert not auth.verify_session(cookie)
+    finally:
+        auth._sessions.pop("n" * 64, None)
+
+
+def test_null_origin_logout_requires_current_session_bound_token(monkeypatch):
+    current_cookie = _signed_cookie("q" * 64)
+    other_cookie = _signed_cookie("r" * 64)
+    expired_cookie = _signed_cookie("s" * 64)
+    logged_out_cookie = _signed_cookie("t" * 64)
+    expired_token = auth.csrf_token_for_session(expired_cookie)
+    logged_out_token = auth.csrf_token_for_session(logged_out_cookie)
+    auth._sessions["s" * 64] = time.time() - 1
+    auth.invalidate_session(logged_out_cookie)
+    monkeypatch.setattr(auth, "is_auth_enabled", lambda: True)
+    try:
+        cases = {
+            "tokenless": (current_cookie, None),
+            "wrong-session token": (
+                current_cookie,
+                auth.csrf_token_for_session(other_cookie),
+            ),
+            "expired session": (expired_cookie, expired_token),
+            "logged-out session": (logged_out_cookie, logged_out_token),
+        }
+        for label, (cookie, token) in cases.items():
+            headers = {
+                "Origin": "null",
+                "Cookie": f"{auth.COOKIE_NAME}={cookie}",
+            }
+            if token:
+                headers[auth.CSRF_HEADER_NAME] = token
+            handler = _post_logout(headers)
+
+            assert handler.status == 403, label
+            assert b"Session expired - reload the page" in handler.wfile.getvalue(), label
+    finally:
+        for raw_token in ("q", "r", "s", "t"):
+            auth._sessions.pop(raw_token * 64, None)
+
+
+def test_null_origin_logout_bypass_is_literal_and_not_cross_site(monkeypatch):
+    cookie = _signed_cookie("u" * 64)
+    token = auth.csrf_token_for_session(cookie)
+    monkeypatch.setattr(auth, "is_auth_enabled", lambda: True)
+    try:
+        cases = {
+            "cross-origin": {"Origin": "https://evil.example"},
+            "uppercase": {"Origin": "NULL"},
+            "leading whitespace": {"Origin": " null"},
+            "trailing whitespace": {"Origin": "null "},
+            "cross-site signal": {
+                "Origin": "null",
+                "Sec-Fetch-Site": "cross-site",
+            },
+            "cross-origin referer": {
+                "Origin": "null",
+                "Referer": "https://evil.example/form",
+            },
+            "referer only": {"Referer": "null"},
+        }
+        for label, provenance_headers in cases.items():
+            handler = _post_logout(
+                {
+                    **provenance_headers,
+                    "Cookie": f"{auth.COOKIE_NAME}={cookie}",
+                    auth.CSRF_HEADER_NAME: token,
+                }
+            )
+
+            assert handler.status == 403, label
+            assert b"Cross-origin mismatch" in handler.wfile.getvalue(), label
+    finally:
+        auth._sessions.pop("u" * 64, None)
+
+
+def test_null_origin_logout_remains_rejected_when_auth_is_disabled(monkeypatch):
+    cookie = _signed_cookie("v" * 64)
+    token = auth.csrf_token_for_session(cookie)
+    monkeypatch.setattr(auth, "is_auth_enabled", lambda: False)
+    try:
+        handler = _post_logout(
+            {
+                "Origin": "null",
+                "Cookie": f"{auth.COOKIE_NAME}={cookie}",
+                auth.CSRF_HEADER_NAME: token,
+            }
+        )
+
+        assert handler.status == 403
+        assert b"Cross-origin mismatch" in handler.wfile.getvalue()
+    finally:
+        auth._sessions.pop("v" * 64, None)
+
+
+def test_null_origin_cannot_authorize_workspace_escape(monkeypatch):
+    cookie = _signed_cookie("w" * 64)
+    token = auth.csrf_token_for_session(cookie)
+    monkeypatch.setattr(auth, "is_auth_enabled", lambda: True)
+    try:
+        handler = _FakeHandler(
+            {
+                "Origin": "null",
+                "Host": "127.0.0.1:8787",
+                "Cookie": f"{auth.COOKIE_NAME}={cookie}",
+                auth.CSRF_HEADER_NAME: token,
+            }
+        )
+        handler.command = "POST"
+
+        routes._handle_escape_authorize(
+            handler,
+            SimpleNamespace(path="/api/escape/authorize", query=""),
+            body={},
+        )
+
+        assert handler.status == 403
+        assert b"browser origin required" in handler.wfile.getvalue()
+    finally:
+        auth._sessions.pop("w" * 64, None)
 
 
 def test_authenticated_allowed_public_origin_accepts_valid_csrf_token(monkeypatch):


### PR DESCRIPTION
<!-- Suggested title: Allow authenticated null-origin native requests -->

## Thinking Path

The existing CSRF contract checks browser provenance before the session-bound token. Native WebViews can send the literal opaque value `Origin: null`, so a client with a current authenticated session and its matching token is rejected before token verification. The narrow fix lets only that exact value skip host matching for normal unsafe API dispatch, while retaining the existing session-token verifier and stricter provenance gates for CORS, extension sidecars, and workspace escape grants.

## What Changed

- Allows exact `Origin: null` with no Referer to reach normal CSRF token verification.
- Rejects the exception when auth is disabled or `Sec-Fetch-Site` reports `cross-site`.
- Keeps concrete cross-origin URLs, case and whitespace variants, missing or wrong tokens, expired sessions, and logged-out sessions denied.
- Keeps workspace escape authorization on its strict concrete same-origin check.
- Documents the changed authentication contract in `README.md` without editing `CHANGELOG.md`.
- Adds route-level success and adjacent negative tests, including explicit CORS preflight and extension-sidecar GET/POST denials for `Origin: null`.

## Why It Matters

Hermes native clients can now perform authenticated state changes without weakening the browser boundary. `Origin: null` is not trusted by itself. The request still needs the current session cookie and that session's valid CSRF token.

## Verification

- `./scripts/test.sh tests/test_issue1909_csrf_token.py -q`: 14 passed in 3.93 seconds on final commit `8c624a9346bfa2c762824210bb24e5412b5f7633`.
- Auth, CSRF diagnostics, CORS, sidecar, session, trusted-header, and escape-grant affected set: 147 passed in 8.65 seconds on the final commit. This includes the review-requested no-CORS-header assertion plus null-origin GET and POST sidecar requests that fail if proxy resolution is reached.
- `python3 scripts/ruff_lint.py --diff origin/master`: 4 changed Python files, 17 existing findings, 0 on changed lines.
- `python3 scripts/critical_markdown_check.py README.md`: passed.
- `git diff --check origin/master..HEAD`: passed.
- The unmodified base fails the new valid-session null-origin logout case with expected 200, actual 403.

The full suite on the initial implementation completed with 15,270 passed, 189 skipped, 1 xfailed, 2 xpassed, 45 subtests passed, and 3 unrelated failures. Two project-context failures reproduced in isolation. The model-grouping failure passed in isolation. After the final stricter escape-grant correction and the review-requested test-only follow-up, the focused and 147-test affected set were rerun; the 15,464-test suite was not rerun.

## Risks / Follow-ups

- CORS preflight and extension-sidecar proxy routes still reject `Origin: null`; both boundaries now have explicit negative regression coverage. This supports native WebViews or bridges that are not constrained by browser CORS and does not claim a general cross-origin browser flow.
- No live native wrapper or real browser was exercised locally.
- Docker and the Python 3.11/3.13 CI matrix were not run locally.
- Release note: Authenticated native clients may send exact `Origin: null` on unsafe requests when they include the current session's valid CSRF token. Concrete cross-origin requests and stricter capability routes remain denied.

## Model Used

Prepared with OpenAI Codex GPT-5.6 SOL as the visible orchestrator. Two visible Paseo subagents used OpenAI Codex GPT-5.6 SOL with xhigh reasoning: implementation agent `7917c08d-6d46-4c33-b74a-7b88c3df71ad` and read-only security reviewer `726f9842-2b0b-4996-8701-55331c750880`. The orchestrator independently reviewed the result, found the escape-grant overreach, narrowed it, and reran the affected tests.

## Contract Routing

This changes authentication and request-validation behavior and adds product-semantics tests. The stable public contract belongs in `README.md`; the patch updates that section. `CHANGELOG.md` remains untouched.

## Contract Change

Previous rule: every browser-origin unsafe request had to pass concrete Origin or Referer host matching before its CSRF token was checked.

New rule: exact `Origin: null`, with no Referer and no explicit cross-site fetch signal, may skip host matching for normal unsafe API routes only when authentication is enabled. The current session's valid CSRF token remains mandatory. CORS, extension-sidecar provenance, and workspace escape authorization keep their stricter concrete-origin rules.
