### PR TITLE
Performance: streaming-session improvements (RC1/RC2/RC3)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -8987,6 +8987,33 @@ def _display_merge_session_is_active(session) -> bool:
     )
 
 
+def _display_merge_streaming_state_signature():
+    """Return the streaming hold-down key for the display-merge cache, or None.
+
+    Mirrors the freeze-marker pattern used by the route session-list cache
+    (#4808) and the CLI/cron projection (#4842): keyed only on the *set* of
+    in-process active stream ids, so it is constant while the same turn(s)
+    stream and changes the moment a stream starts or stops. Entries stored
+    under this marker are accepted by ``_display_merge_cache_entry_usable``
+    only within ``_DISPLAY_MERGE_STREAMING_TTL_SECONDS``, bounding any live-tail
+    staleness to that window; a sidecar checkpoint save, a new in-memory
+    message row, or the stream's own start/stop invalidates sooner. Streams
+    that this process cannot see (cross-process gateway/CLI turns) leave the
+    active set empty and therefore the marker None — those sessions stay on
+    the uncached path (fail closed).
+    """
+    try:
+        active = _active_stream_ids()
+    except Exception:
+        return None
+    if not active:
+        return None
+    try:
+        return ("streaming", tuple(sorted(str(x) for x in active)))
+    except Exception:
+        return ("streaming",)
+
+
 def _display_merge_cached_messages(session, sidecar_messages, *, msg_before=None):
     """Return the memoized merged transcript, or None when it can't be reused.
 
@@ -8996,12 +9023,29 @@ def _display_merge_cached_messages(session, sidecar_messages, *, msg_before=None
     than a fingerprint computed FROM the loaded rows -- otherwise the key could
     not be built without paying exactly the cost we are trying to avoid.
 
-    Fail-closed by construction: returns None whenever the session is active,
-    the key cannot be built, or the cached entry does not match, and the caller
-    then performs the normal full load + merge.
+    Inactive sessions key on that exact state.db revision. Active sessions
+    (in-process stream registered) probe under the streaming freeze marker
+    instead, whose entries expire after ``_DISPLAY_MERGE_STREAMING_TTL_SECONDS``
+    — the live tail can therefore lag by at most the TTL and self-heals on the
+    next request, while a sidecar checkpoint save or a new message row still
+    invalidates immediately through the other key components.
+
+    Fail-closed by construction: returns None for ``msg_before`` paging, for an
+    active session without a registered in-process stream (cross-process
+    gateway/CLI turn — the in-memory tail cannot be verified against anything
+    this process can see), when the key cannot be built, or when the cached
+    entry does not match, and the caller then performs the normal full load +
+    merge.
     """
-    if msg_before is not None or _display_merge_session_is_active(session):
+    if msg_before is not None:
         return None
+    if _display_merge_session_is_active(session):
+        streaming_marker = _display_merge_streaming_state_signature()
+        if streaming_marker is None:
+            return None
+        state_sig = streaming_marker
+    else:
+        state_sig = _DISPLAY_STATE_SIGNATURE_UNSET
     sid = str(getattr(session, "session_id", "") or "")
     if not sid:
         return None
@@ -9020,7 +9064,9 @@ def _display_merge_cached_messages(session, sidecar_messages, *, msg_before=None
     # Building the key requires the sidecar rows (cheap: already in memory or
     # served from the lineage cache) but not the state.db rows -- that
     # asymmetry is the whole point.
-    cache_key = _display_merge_cache_key(session, sidecar_messages, None)
+    cache_key = _display_merge_cache_key(
+        session, sidecar_messages, None, state_db_signature=state_sig
+    )
     if cache_key is None:
         return None
     with _display_merge_cache_lock:
@@ -9062,39 +9108,60 @@ def _limited_webui_messages_for_display_with_sidecar(
     # historical transcripts (~2-3s per request: json.dumps merge keys +
     # loose-content probes per row), and GET /api/session re-runs it on every
     # open/poll. Memoize per session id. Validity is fail-closed:
-    #   - only INACTIVE sessions (no active stream, no pending user message):
-    #     an active session's in-memory tail can be ahead of its disk
-    #     signature, so it always recomputes;
-    #   - the child sidecar's exact stat signature plus every lineage parent
+    #   - INACTIVE sessions (no active stream, no pending user message) key on:
+    #     the child sidecar's exact stat signature plus every lineage parent
     #     signature recorded by _webui_sidecar_lineage_messages_for_display;
-    #   - the sidecar row count and last timestamp (guards unsaved in-memory
-    #     appends that have not reached disk yet);
-    #   - a content fingerprint of the (bounded) state.db rows.
-    # Any uncertainty (missing signature, fingerprint failure) skips caching.
+    #     the sidecar row count and last timestamp (guards unsaved in-memory
+    #     appends that have not reached disk yet); and a content fingerprint
+    #     (or commit-reliable revision) of the (bounded) state.db rows.
+    #   - ACTIVE sessions with an in-process registered stream key on the
+    #     streaming freeze marker instead: an exact per-delta state.db key
+    #     would churn on every streamed row and force the O(history) merge on
+    #     every request, so the marker holds the entry steady for the same
+    #     turn(s) and _display_merge_cache_entry_usable expires it after
+    #     _DISPLAY_MERGE_STREAMING_TTL_SECONDS. A sidecar checkpoint save, a
+    #     new in-memory message row, or the stream's own start/stop still
+    #     invalidates immediately through the other key components, and a
+    #     cross-process (gateway/CLI) turn leaves the marker None — those stay
+    #     on the uncached path.
+    # Any uncertainty (missing signature, fingerprint failure, unregistered
+    # stream) skips caching.
     cache_key = None
     # A msg_before request deliberately reads a different (uncapped) state.db
     # scope than the initial tail request.  It must bypass both cache layers:
     # skipping only the pre-load probe still let this inner lookup reuse the
     # initial 50k-row backstop merge and made the oldest row unreachable.
-    if msg_before is None and not _display_merge_session_is_active(session):
-        if state_db_signature is _DISPLAY_STATE_SIGNATURE_UNSET:
-            _state_key = _state_db_rows_fingerprint(state_db_messages)
-        else:
-            _state_key = state_db_signature
-            if _state_key is not None:
-                _current_key = _state_db_session_signature(
-                    getattr(session, "session_id", None),
-                    getattr(session, "profile", None) or None,
-                )
-                if _current_key != _state_key:
-                    _state_key = None
-        if _state_key is not None:
+    _display_active = _display_merge_session_is_active(session)
+    _streaming_marker = (
+        _display_merge_streaming_state_signature() if _display_active else None
+    )
+    if msg_before is None and (not _display_active or _streaming_marker is not None):
+        if _display_active:
             cache_key = _display_merge_cache_key(
                 session,
                 sidecar_messages,
                 state_db_messages,
-                state_db_signature=_state_key,
+                state_db_signature=_streaming_marker,
             )
+        else:
+            if state_db_signature is _DISPLAY_STATE_SIGNATURE_UNSET:
+                _state_key = _state_db_rows_fingerprint(state_db_messages)
+            else:
+                _state_key = state_db_signature
+                if _state_key is not None:
+                    _current_key = _state_db_session_signature(
+                        getattr(session, "session_id", None),
+                        getattr(session, "profile", None) or None,
+                    )
+                    if _current_key != _state_key:
+                        _state_key = None
+            if _state_key is not None:
+                cache_key = _display_merge_cache_key(
+                    session,
+                    sidecar_messages,
+                    state_db_messages,
+                    state_db_signature=_state_key,
+                )
     if cache_key is not None:
         sid = str(getattr(session, "session_id", "") or "")
         with _display_merge_cache_lock:
@@ -9145,9 +9212,10 @@ def _limited_webui_messages_for_display_with_sidecar(
 # perf: memoized sidecar↔state.db display merges for GET /api/session.
 # See _limited_webui_messages_for_display_with_sidecar for the validity rules.
 _DISPLAY_MERGE_CACHE_MAX = 16
-# Legacy streaming-freeze keys are still accepted defensively and remain
-# tightly bounded. Production streaming keys now carry an exact target-session
-# digest, so unrelated deltas stay stable without hiding target mutations.
+# Streaming-freeze keys ("streaming", <sorted active stream ids>) are produced
+# by the active-session fill/probe path (RC1) and remain tightly bounded:
+# _display_merge_cache_entry_usable accepts them only within this TTL, so the
+# live tail can lag by at most 5s and self-heals on the next request.
 _DISPLAY_MERGE_STREAMING_TTL_SECONDS = 5.0
 _display_merge_cache: "OrderedDict[str, dict]" = OrderedDict()
 _display_merge_cache_lock = threading.Lock()
@@ -12967,11 +13035,13 @@ def _handle_session_get(handler, parsed) -> bool:
             # falls through to the normal full load, so this can only skip
             # work that would have produced an identical merged result.
             _display_cache_hit = None
-            if (
-                msg_limit is not None
-                and not getattr(s, "active_stream_id", None)
-                and not getattr(s, "pending_user_message", None)
-            ):
+            if msg_limit is not None:
+                # RC1: active sessions probe the display-merge cache too.
+                # _display_merge_cached_messages fails closed for a stream
+                # this process cannot see (cross-process gateway/CLI turn)
+                # and applies the streaming TTL via the freeze-marker key,
+                # so a hit here never hides the live tail for longer than
+                # _DISPLAY_MERGE_STREAMING_TTL_SECONDS.
                 _display_cache_hit = _display_merge_cached_messages(
                     s,
                     limited_sidecar_messages,

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -150,7 +150,370 @@ def _discard_cached_summary(path: Path) -> None:
         _SUMMARY_CACHE.pop(str(path), None)
 
 
+_LINE_BREAK_CHARS = "\n\r\v\f\x1c\x1d\x1e\x85\u2028\u2029"
+
+
+def _splitline_terminator(element: str) -> str:
+    """Return the ``str.splitlines`` terminator of ``element`` ("" if none).
+
+    The journal writer always emits "\\n", but the historical reader parsed
+    ``read_text().splitlines()`` — which also breaks on \\r\\n, \\v, \\f, \\x1c,
+    \\x1d, \\x1e, \\x85, \\u2028 and \\u2029 — so incremental parsing must use
+    the exact same line semantics to keep responses identical.
+    """
+    if element and element[-1] in _LINE_BREAK_CHARS:
+        if element.endswith("\r\n"):
+            return "\r\n"
+        return element[-1]
+    return ""
+
+
+def _parse_journal_line(content: str, line_no: int, events: list, malformed: list) -> None:
+    """Parse one journal line with the historical ``_read_jsonl`` row rules."""
+    if not content.strip():
+        return
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        malformed.append({"line": line_no, "raw": content})
+        return
+    if isinstance(parsed, dict):
+        events.append(parsed)
+    else:
+        malformed.append({"line": line_no, "raw": content})
+
+
+# RC2: incremental read cache for the run journal.
+#
+# ``_read_jsonl`` is the single read chokepoint for ``find_run_summary``,
+# ``latest_run_summary``, ``read_run_events`` and ``_next_seq``. During a live
+# turn the journal grows on every streamed event (including per-token rows), so
+# every summary-cache invalidation forced a full re-read + re-parse of the whole
+# file — and ``_run_journal_live_snapshot`` pays that cost twice per request
+# (once via ``find_run_summary``, once via ``read_run_events``).
+#
+# The cache stores the parsed rows up to a byte watermark (end of the last
+# COMPLETE line). A later read may reuse them only when continuity is verified:
+#   - same file identity (st_dev, st_ino) — replace/rotate falls back;
+#   - the file did not shrink — truncate falls back;
+#   - same size requires unchanged mtime/ctime — same-size rewrite falls back
+#     (ctime cannot be forged back, mirroring _summary_cache_signature);
+#   - growth requires the ≤8KiB region before the watermark to be
+#     byte-identical (append-only overlap proof) AND the first new complete row
+#     to continue the seq watermark (seq == last_seq + 1, per-row envelope
+#     ``event_id == f"{run_id}:{seq}"`` — the same identity the replay reader
+#     enforces). The writer is append-only by construction (O_APPEND, no
+#     truncate/rewrite path) and reserves gapless seqs (_reserve_next_seq), so
+#     a passing check means the tail is purely new rows.
+# Any uncertainty (shrink, metadata change, overlap mismatch, malformed first
+# row, undecodable bytes, stat failure) falls back to the full read, which
+# returns exactly the historical result — the cache only chooses between a fast
+# path and the historical path, never between different contents.
+# A trailing partial line (writer mid-append) is reported for the current read
+# exactly like the historical reader reported it, but is NOT consumed: the
+# watermark stays before it, so the completed line is parsed once later — no
+# loss, no duplication.
+_JOURNAL_READ_TAIL_VERIFY_BYTES = 8192
+_JOURNAL_READ_CACHE_MAX_ENTRIES = 4
+_JOURNAL_READ_CACHE_MAX_TOTAL_BYTES = 32 * 1024 * 1024
+_JOURNAL_READ_CACHE: "OrderedDict[str, dict]" = OrderedDict()
+_JOURNAL_READ_CACHE_LOCK = threading.Lock()
+# Read-path counters (diagnostics/tests): full = full re-read+parse; tail =
+# incremental tail parse; fast = watermark hit with zero parse.
+_JOURNAL_READ_PATH_STATS = {"full": 0, "tail": 0, "fast": 0}
+
+
+def _journal_read_stats_bump(kind: str) -> None:
+    with _JOURNAL_READ_CACHE_LOCK:
+        _JOURNAL_READ_PATH_STATS[kind] = _JOURNAL_READ_PATH_STATS.get(kind, 0) + 1
+
+
+def _journal_read_cache_get(key: str) -> dict | None:
+    with _JOURNAL_READ_CACHE_LOCK:
+        entry = _JOURNAL_READ_CACHE.get(key)
+        if entry is None:
+            return None
+        _JOURNAL_READ_CACHE.move_to_end(key, last=True)
+        return entry
+
+
+def _journal_read_cache_store(key: str, entry: dict) -> None:
+    with _JOURNAL_READ_CACHE_LOCK:
+        _JOURNAL_READ_CACHE[key] = entry
+        _JOURNAL_READ_CACHE.move_to_end(key, last=True)
+
+        def cached_total() -> int:
+            return sum(int(item.get("cached_bytes") or 0) for item in _JOURNAL_READ_CACHE.values())
+
+        # Evict LRU-first; never evict the entry just stored while it is the
+        # only one left (one oversized journal is tolerated over losing the
+        # cache entirely).
+        while len(_JOURNAL_READ_CACHE) > 1 and (
+            len(_JOURNAL_READ_CACHE) > _JOURNAL_READ_CACHE_MAX_ENTRIES
+            or cached_total() > _JOURNAL_READ_CACHE_MAX_TOTAL_BYTES
+        ):
+            evicted = None
+            for candidate in list(_JOURNAL_READ_CACHE.keys()):
+                if candidate == key:
+                    continue
+                evicted = _JOURNAL_READ_CACHE.pop(candidate)
+                break
+            if evicted is None:
+                break
+
+
+def _journal_read_cache_discard(key: str) -> None:
+    with _JOURNAL_READ_CACHE_LOCK:
+        _JOURNAL_READ_CACHE.pop(key, None)
+
+
 def _read_jsonl(path: Path) -> tuple[list[dict], list[dict]]:
+    events: list[dict] = []
+    malformed: list[dict] = []
+    key = str(path)
+    try:
+        stat = path.stat()
+    except OSError:
+        _journal_read_cache_discard(key)
+        return events, malformed
+    entry = _journal_read_cache_get(key)
+    if (
+        entry is not None
+        and entry.get("dev") == stat.st_dev
+        and entry.get("ino") == stat.st_ino
+    ):
+        result = _read_jsonl_incremental(path, entry)
+        if result is not None:
+            return result
+    _journal_read_stats_bump("full")
+    return _read_jsonl_full(path)
+
+
+def _read_jsonl_full(path: Path) -> tuple[list[dict], list[dict]]:
+    """Historical full read+parse; seeds the incremental read cache."""
+    events: list[dict] = []
+    malformed: list[dict] = []
+    key = str(path)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        _journal_read_cache_discard(key)
+        return events, malformed
+    elements = text.splitlines(keepends=True)
+    partial: str | None = None
+    if elements and _splitline_terminator(elements[-1]) == "":
+        partial = elements[-1]
+        elements = elements[:-1]
+    consumed_lines = 0
+    for element in elements:
+        consumed_lines += 1
+        terminator = _splitline_terminator(element)
+        content = element[: len(element) - len(terminator)]
+        _parse_journal_line(content, consumed_lines, events, malformed)
+    fragment_events: list[dict] = []
+    fragment_malformed: list[dict] = []
+    if partial is not None:
+        # A trailing line still being appended is reported for THIS read exactly
+        # like the historical reader did, but stays unconsumed: the watermark
+        # remains before it, so the completed line is parsed exactly once later.
+        # Parse it into separate lists so it never leaks into the read cache.
+        _parse_journal_line(partial, consumed_lines + 1, fragment_events, fragment_malformed)
+    consumed_blob = b""
+    try:
+        consumed_blob = "".join(elements).encode("utf-8")
+    except Exception:  # pragma: no cover - encode of decoded text cannot fail
+        consumed_blob = b""
+    last_seq = 0
+    run_id = None
+    for event in reversed(events):
+        seq = event.get("seq")
+        if isinstance(seq, int) and not isinstance(seq, bool):
+            last_seq = int(seq)
+            raw_run_id = str(event.get("run_id") or "").strip()
+            run_id = raw_run_id or None
+            break
+    try:
+        stat = path.stat()
+        if stat.st_size >= len(consumed_blob) and consumed_blob:
+            _journal_read_cache_store(key, {
+                "dev": int(stat.st_dev),
+                "ino": int(stat.st_ino),
+                "mtime_ns": int(stat.st_mtime_ns),
+                "ctime_ns": int(stat.st_ctime_ns),
+                "consumed_bytes": len(consumed_blob),
+                "consumed_lines": consumed_lines,
+                "events": events,
+                "malformed": malformed,
+                "last_seq": last_seq,
+                "run_id": run_id,
+                "verify_tail": consumed_blob[-_JOURNAL_READ_TAIL_VERIFY_BYTES:],
+                "cached_bytes": len(consumed_blob),
+            })
+        else:
+            _journal_read_cache_discard(key)
+    except OSError:
+        _journal_read_cache_discard(key)
+    # Hand out fresh top-level objects (historical semantics: every read parsed
+    # fresh rows) while the cache keeps its own copies. The unconsumed trailing
+    # fragment rows (if any) are transient and come last, in file order.
+    return (
+        [dict(event) for event in events] + [dict(event) for event in fragment_events],
+        [dict(row) for row in malformed] + [dict(row) for row in fragment_malformed],
+    )
+
+
+def _read_jsonl_incremental(path: Path, entry: dict) -> tuple[list[dict], list[dict]] | None:
+    """Extend a cached journal read incrementally, or None to fall back.
+
+    The caller already verified the cached (st_dev, st_ino) identity against a
+    fresh stat; this re-checks on the open fd (races between stat and open),
+    verifies the append-only overlap before the watermark, parses only the new
+    complete rows under the exact historical line semantics, and re-stores the
+    extended entry.
+    """
+    key = str(path)
+    consumed_bytes = int(entry["consumed_bytes"])
+    try:
+        fh = open(path, "rb")
+    except FileNotFoundError:
+        _journal_read_cache_discard(key)
+        return [], []
+    except OSError:
+        return None
+    try:
+        fd_stat = os.fstat(fh.fileno())
+        if int(fd_stat.st_dev) != int(entry["dev"]) or int(fd_stat.st_ino) != int(entry["ino"]):
+            return None
+        if int(fd_stat.st_size) == consumed_bytes:
+            if (
+                int(fd_stat.st_mtime_ns) == int(entry["mtime_ns"])
+                and int(fd_stat.st_ctime_ns) == int(entry["ctime_ns"])
+            ):
+                _journal_read_stats_bump("fast")
+                return (
+                    [dict(event) for event in entry["events"]],
+                    [dict(row) for row in entry["malformed"]],
+                )
+            return None
+        if int(fd_stat.st_size) < consumed_bytes:
+            return None
+        overlap = min(consumed_bytes, _JOURNAL_READ_TAIL_VERIFY_BYTES)
+        fh.seek(consumed_bytes - overlap)
+        head = fh.read(overlap)
+        if head != entry["verify_tail"]:
+            return None
+        tail_blob = fh.read()
+    except OSError:
+        return None
+    finally:
+        fh.close()
+    try:
+        text = tail_blob.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+    tail_events: list[dict] = []
+    tail_malformed: list[dict] = []
+    fragment_events: list[dict] = []
+    fragment_malformed: list[dict] = []
+    new_consumed_bytes = consumed_bytes
+    new_consumed_lines = int(entry["consumed_lines"])
+    expected_seq = int(entry["last_seq"] or 0) + 1
+    continuity_verified = False
+    last_seq = int(entry["last_seq"] or 0)
+    run_id = entry.get("run_id")
+    for element in text.splitlines(keepends=True):
+        terminator = _splitline_terminator(element)
+        if terminator == "":
+            # Partial trailing line: report it for this read (historical
+            # parity) but leave it unconsumed for the next read.
+            content = element
+            if content.strip():
+                try:
+                    parsed = json.loads(content)
+                except json.JSONDecodeError:
+                    fragment_malformed.append({"line": new_consumed_lines + 1, "raw": content})
+                else:
+                    if isinstance(parsed, dict):
+                        fragment_events.append(parsed)
+                    else:
+                        fragment_malformed.append({"line": new_consumed_lines + 1, "raw": content})
+            break
+        raw_bytes = element.encode("utf-8")
+        content = element[: len(element) - len(terminator)]
+        line_no = new_consumed_lines + 1
+        if not content.strip():
+            new_consumed_lines = line_no
+            new_consumed_bytes += len(raw_bytes)
+            continue
+        try:
+            parsed = json.loads(content)
+        except json.JSONDecodeError:
+            # A complete malformed row makes the tail unverifiable — fall back
+            # to the full read, which returns exactly the historical rows.
+            return None
+        if not isinstance(parsed, dict):
+            return None
+        seq = parsed.get("seq")
+        if not continuity_verified:
+            if not isinstance(seq, int) or isinstance(seq, bool) or int(seq) != expected_seq:
+                return None
+            row_run_id = str(parsed.get("run_id") or "").strip() or None
+            if parsed.get("event_id") != f"{row_run_id}:{int(seq)}":
+                return None
+            if run_id is None:
+                run_id = row_run_id
+            continuity_verified = True
+        elif run_id is not None and str(parsed.get("run_id") or "").strip() and str(parsed.get("run_id")) != run_id:
+            # Rows of one journal file share one run_id; a mismatch is not an
+            # append of this run — fall back rather than guess.
+            return None
+        last_seq = int(seq) if isinstance(seq, int) and not isinstance(seq, bool) else last_seq
+        tail_events.append(parsed)
+        new_consumed_lines = line_no
+        new_consumed_bytes += len(raw_bytes)
+    if not tail_events and not fragment_events and not fragment_malformed:
+        # Nothing usable was read (e.g. only whitespace) — let the full read
+        # decide, keeping the result identical by construction.
+        return None
+    try:
+        post_stat = path.stat()
+    except OSError:
+        return None
+    if int(post_stat.st_size) < new_consumed_bytes:
+        return None
+    merged_events = entry["events"] + tail_events
+    merged_malformed = entry["malformed"] + tail_malformed
+    new_verify_tail = (entry["verify_tail"] + tail_blob[: new_consumed_bytes - consumed_bytes])[
+        -_JOURNAL_READ_TAIL_VERIFY_BYTES:
+    ]
+    _journal_read_cache_store(key, {
+        "dev": int(entry["dev"]),
+        "ino": int(entry["ino"]),
+        "mtime_ns": int(post_stat.st_mtime_ns),
+        "ctime_ns": int(post_stat.st_ctime_ns),
+        "consumed_bytes": new_consumed_bytes,
+        "consumed_lines": new_consumed_lines,
+        "events": merged_events,
+        "malformed": merged_malformed,
+        "last_seq": last_seq,
+        "run_id": run_id,
+        "verify_tail": new_verify_tail,
+        "cached_bytes": new_consumed_bytes,
+    })
+    _journal_read_stats_bump("tail")
+    return (
+        [dict(event) for event in merged_events] + [dict(event) for event in fragment_events],
+        [dict(row) for row in merged_malformed] + [dict(row) for row in fragment_malformed],
+    )
+
+
+def _read_jsonl_legacy(path: Path) -> tuple[list[dict], list[dict]]:
+    """The pre-RC2 full reader, kept verbatim as the parity oracle for tests.
+
+    Production reads go through ``_read_jsonl`` (incremental with full-read
+    fallback); these tests prove both paths return identical rows for the same
+    file state, including partial lines, malformed rows and exotic breaks.
+    """
     events: list[dict] = []
     malformed: list[dict] = []
     try:
@@ -754,6 +1117,12 @@ def delete_run_journal(session_id: str, *, session_dir: Path | None = None) -> b
         with _SUMMARY_CACHE_LOCK:
             for cache_key in [entry for entry in _SUMMARY_CACHE if str(Path(entry).parent) == dir_key]:
                 del _SUMMARY_CACHE[cache_key]
+        with _JOURNAL_READ_CACHE_LOCK:
+            for cache_key in [
+                entry for entry in _JOURNAL_READ_CACHE
+                if str(Path(entry).parent) == dir_key
+            ]:
+                del _JOURNAL_READ_CACHE[cache_key]
     return removed
 
 

--- a/static/messages.js
+++ b/static/messages.js
@@ -5595,11 +5595,42 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     }
 
     S.toolCalls=inflight.toolCalls;
-    persistInflightState();
+    // rc3b: this runs for every tool/tool_complete SSE event (198 on a
+    // tool-heavy replay); the direct persist wrote the WHOLE inflight map to
+    // localStorage (synchronous IO) per event. The 2s trailing throttle keeps
+    // the same persistence contract the token path already accepted
+    // (WS2.3-style); terminal paths still cancel the timer and clear/flush
+    // synchronously, so at most 2s of tool state can be lost on a crash.
+    _throttledPersist();
     return tc;
   }
 
   let _lastRenderMs=0;
+  // rc3a (fase 6): the reasoning SSE handler used to rebuild the thinking card
+  // and anchor rows for EVERY reasoning event. Replaying a tool-heavy active
+  // session delivers thousands of reasoning events in one burst, so each event
+  // caused a full text-node write on the card plus a forced layout through
+  // scrollIfPinned — the measured main-thread starvation. The handler now only
+  // advances the reasoning accumulators and defers the DOM write to the render
+  // frame; the state layer (reasoningText/liveReasoningText/INFLIGHT) is still
+  // updated synchronously per event, so no event content is ever dropped.
+  let _pendingReasoningDomFlush=false;
+  function _flushPendingReasoningDom(){
+    if(!_pendingReasoningDomFlush) return;
+    _pendingReasoningDomFlush=false;
+    if(_streamFinalized) return;
+    if(!S.session||S.session.session_id!==activeSid||S.activeStreamId!==streamId) return;
+    const liveThinkingText=_liveThinkingText();
+    const anchorReasoningFallback={};
+    if(!_upsertAnchorReasoning(liveThinkingText, anchorReasoningFallback)){
+      _updateLiveThinkingCard(liveThinkingText,{
+        ...anchorReasoningFallback,
+        anchorRenderFallback:true,
+        sessionId:activeSid,
+        streamId,
+      });
+    }
+  }
   // Parse-result cache: _scheduleRender can accept a pre-computed _parseStreamState()
   // from the token event handler, avoiding a duplicate O(n) scan inside _doRender
   // when the rAF fires before the next token arrives.
@@ -5642,6 +5673,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // writes to suppress Chromium scroll re-anchoring during streaming growth.
       if(typeof window._fixMobileScrollJank==='function') window._fixMobileScrollJank();
       _lastRenderMs=performance.now();
+      _flushPendingReasoningDom();
       const parsed=_cachedParsed&&_cachedParsedText===assistantText&&_cachedParsedReasoning===liveReasoningText ? _cachedParsed : _parseStreamState();
       _cachedParsed=null;
       _renderLiveThinking(parsed);
@@ -5764,6 +5796,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         return;
       }
       if(reasoningEcho) _stripLiveReasoningEcho(visible);
+      // rc3a: flush the pending reasoning frame write before the accumulators
+      // are reset (same ordering contract as the tool boundary below).
+      _flushPendingReasoningDom();
       liveReasoningText='';
       if(alreadyStreamed){
         if(!S.session||S.session.session_id!==activeSid){
@@ -5846,17 +5881,13 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       liveReasoningText += text;
       if(d.text&&S.session&&S.session.session_id===activeSid) _completeAutomaticCompressionOnLiveProgress(activeSid);
       syncInflightAssistantMessage();
+      // rc3a: defer the thinking-card/anchor DOM write to the render frame.
+      // Per-event writes starved the main thread on replay bursts (fase 6);
+      // the accumulators are already updated synchronously above, so the flush
+      // renders the exact same final content, at most one frame later.
       if(text&&S.session&&S.session.session_id===activeSid&&S.activeStreamId===streamId){
-        const liveThinkingText=_liveThinkingText();
-        const anchorReasoningFallback={};
-        if(!_upsertAnchorReasoning(liveThinkingText, anchorReasoningFallback)){
-          _updateLiveThinkingCard(liveThinkingText,{
-            ...anchorReasoningFallback,
-            anchorRenderFallback:true,
-            sessionId:activeSid,
-            streamId,
-          });
-        }
+        _pendingReasoningDomFlush=true;
+        _scheduleRender();
       }
     });
 
@@ -5876,6 +5907,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
       if(S.session&&S.session.session_id===activeSid&&typeof scheduleRenderSessionArtifacts==='function') scheduleRenderSessionArtifacts();
       if(!S.session||S.session.session_id!==activeSid) return;
+      // rc3a: flush any pending per-frame reasoning DOM write BEFORE the
+      // accumulators are reset, so the reasoning→tool ordering (and content)
+      // stays identical to the per-event behavior.
+      _flushPendingReasoningDom();
       // Provider reasoning/thinking is a Worklog Thinking Card, separate from
       // tool cards. Close the current live card before appending a tool row.
       if(typeof finalizeThinkingCard==='function') finalizeThinkingCard();
@@ -5889,7 +5924,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       }
       _flushPendingSegmentRender({force:true});
       appendLiveToolCard(tc,{sessionId:activeSid,streamId});
-      snapshotLiveTurn();
+      // rc3b: trailing snapshot instead of a synchronous outerHTML serialize of
+      // the whole (growing) live turn per tool event (WS2.2 throttle contract);
+      // the session-switch path still captures synchronously on its own.
+      _throttledSnapshotLiveTurn();
       _freshSegment=true;
       _smdEndParser();
       _resetAssistantSegment();
@@ -5930,7 +5968,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       } else {
         appendLiveToolCard(tc,{sessionId:activeSid,streamId});
       }
-      snapshotLiveTurn();
+      // rc3b: trailing snapshot (WS2.2 contract) — same rationale as 'tool'.
+      _throttledSnapshotLiveTurn();
       scrollIfPinned();
     });
 

--- a/tests/test_display_merge_cache.py
+++ b/tests/test_display_merge_cache.py
@@ -7,7 +7,13 @@ every request (~2-3s for multi-thousand-message transcripts). The cache must:
 - serve copies (caller mutation cannot corrupt the cache),
 - invalidate when the sidecar file changes on disk,
 - invalidate when the state.db rows change,
-- never cache ACTIVE sessions (active_stream_id / pending_user_message).
+- never cache an ACTIVE session whose stream this process cannot see
+  (active_stream_id / pending_user_message without a registered in-process
+  stream — cross-process gateway/CLI turn, fail closed),
+- for an ACTIVE session WITH a registered in-process stream, reuse the memoized
+  merge only under the streaming freeze marker and only within
+  ``_DISPLAY_MERGE_STREAMING_TTL_SECONDS`` (RC1), while ``msg_before`` paging
+  keeps bypassing the cache entirely.
 """
 
 import time
@@ -33,7 +39,12 @@ def routes_env(tmp_path, monkeypatch):
     monkeypatch.setattr(routes, "SESSION_DIR", session_dir)
     with routes._display_merge_cache_lock:
         routes._display_merge_cache.clear()
+    streams_before = set(config.STREAMS.keys())
     yield SimpleNamespace(config=config, models=models, routes=routes)
+    # Remove only the stream registry entries this module's tests added.
+    for stream_id in list(config.STREAMS.keys()):
+        if stream_id not in streams_before:
+            config.STREAMS.pop(stream_id, None)
     with routes._display_merge_cache_lock:
         routes._display_merge_cache.clear()
 
@@ -108,7 +119,13 @@ def test_cache_invalidated_by_state_rows_change(routes_env):
     assert any(m.get("content") == "brand new state row" for m in merged)
 
 
-def test_active_session_never_cached(routes_env):
+def test_active_session_without_registered_stream_is_never_cached(routes_env):
+    """Fail-closed: a stream this process cannot see must not be cached.
+
+    An in-memory tail from a cross-process (gateway/CLI) turn cannot be
+    verified against any signature this process can build, so without a
+    registered in-process stream the merge always recomputes.
+    """
     routes = routes_env.routes
     s = _make_session(routes_env, sid="20260101_000000_cache5")
     s.active_stream_id = "stream-live"
@@ -117,3 +134,133 @@ def test_active_session_never_cached(routes_env):
     routes._display_merge_cache.clear()
     routes._limited_webui_messages_for_display_with_sidecar(s, None, rows)
     assert s.session_id not in routes._display_merge_cache
+
+
+def _register_stream(routes_env, stream_id="stream-live"):
+    """Make ``stream_id`` visible to the in-process active-stream registry."""
+    import api.config as config
+
+    routes_env.config.STREAMS[stream_id] = {"session_id": "test"}
+    return stream_id
+
+
+def test_active_session_with_registered_stream_uses_streaming_cache(routes_env):
+    """RC1: an in-process active stream may reuse the memoized merge.
+
+    The entry must be stored under the streaming freeze marker so
+    ``_display_merge_cache_entry_usable`` bounds it to the streaming TTL, and
+    repeated tail loads within the TTL must not re-run the O(history) merge.
+    """
+    routes = routes_env.routes
+    s = _make_session(routes_env, sid="20260101_000000_cache6")
+    s.active_stream_id = "stream-live"
+    _register_stream(routes_env)
+    rows = _state_rows(s.messages[-1]["timestamp"])
+
+    routes._display_merge_cache.clear()
+    merge_calls = {"n": 0}
+    real_merge = routes.merge_session_messages_append_only
+
+    def counting_merge(*args, **kwargs):
+        merge_calls["n"] += 1
+        return real_merge(*args, **kwargs)
+
+    routes.merge_session_messages_append_only = counting_merge
+    try:
+        first = routes._limited_webui_messages_for_display_with_sidecar(s, None, rows)
+        second = routes._limited_webui_messages_for_display_with_sidecar(s, None, rows)
+    finally:
+        routes.merge_session_messages_append_only = real_merge
+
+    with routes._display_merge_cache_lock:
+        entry = routes._display_merge_cache.get(s.session_id)
+    assert entry is not None, "expected a streaming cache entry"
+    state_key = entry["key"][4]
+    assert isinstance(state_key, tuple) and state_key[0] == "streaming", (
+        "active-session entries must be keyed on the streaming freeze marker"
+    )
+    assert merge_calls["n"] == 1, "second tail load within the TTL re-ran the merge"
+    assert [m.get("content") for m in first] == [m.get("content") for m in second]
+    assert any(m.get("content") == "state row 0" for m in second)
+
+
+def test_streaming_cache_entry_expires_after_ttl(routes_env, monkeypatch):
+    """The streaming hold-down is TTL-bounded: after 5s the merge recomputes."""
+    routes = routes_env.routes
+    s = _make_session(routes_env, sid="20260101_000000_cache7")
+    s.active_stream_id = "stream-live"
+    _register_stream(routes_env)
+    rows = _state_rows(s.messages[-1]["timestamp"])
+
+    routes._display_merge_cache.clear()
+    merge_calls = {"n": 0}
+    real_merge = routes.merge_session_messages_append_only
+
+    def counting_merge(*args, **kwargs):
+        merge_calls["n"] += 1
+        return real_merge(*args, **kwargs)
+
+    routes.merge_session_messages_append_only = counting_merge
+    now = [1000.0]
+    monkeypatch.setattr(routes.time, "monotonic", lambda: now[0])
+    try:
+        routes._limited_webui_messages_for_display_with_sidecar(s, None, rows)
+        now[0] += routes._DISPLAY_MERGE_STREAMING_TTL_SECONDS + 0.1
+        routes._limited_webui_messages_for_display_with_sidecar(s, None, rows)
+    finally:
+        routes.merge_session_messages_append_only = real_merge
+
+    assert merge_calls["n"] == 2, "expired streaming entry must recompute the merge"
+
+
+def test_new_in_memory_row_invalidates_streaming_cache(routes_env):
+    """A new message row must be visible on the next tail load immediately."""
+    routes = routes_env.routes
+    s = _make_session(routes_env, sid="20260101_000000_cache8")
+    s.active_stream_id = "stream-live"
+    _register_stream(routes_env)
+    rows = _state_rows(s.messages[-1]["timestamp"])
+
+    routes._display_merge_cache.clear()
+    routes._limited_webui_messages_for_display_with_sidecar(s, None, rows)
+    s.messages.append({
+        "role": "assistant",
+        "content": "live tail row",
+        "timestamp": time.time() + 50,
+    })
+    merged = routes._limited_webui_messages_for_display_with_sidecar(s, None, rows)
+    assert any(m.get("content") == "live tail row" for m in merged)
+
+
+def test_msg_before_pagination_bypasses_streaming_cache(routes_env):
+    """RC1 must not change the msg_before contract: paging never reuses the
+    initial tail merge (uncapped read scope; the tail entry may have been built
+    from a since-bounded state.db read, so reusing it could hide older rows)."""
+    routes = routes_env.routes
+    s = _make_session(routes_env, sid="20260101_000000_cache9")
+    s.active_stream_id = "stream-live"
+    _register_stream(routes_env)
+    rows = _state_rows(s.messages[-1]["timestamp"])
+
+    routes._display_merge_cache.clear()
+    merge_calls = {"n": 0}
+    real_merge = routes.merge_session_messages_append_only
+
+    def counting_merge(*args, **kwargs):
+        merge_calls["n"] += 1
+        return real_merge(*args, **kwargs)
+
+    routes.merge_session_messages_append_only = counting_merge
+    try:
+        routes._limited_webui_messages_for_display_with_sidecar(s, None, rows)
+        assert merge_calls["n"] == 1
+        paged = routes._limited_webui_messages_for_display_with_sidecar(
+            s, None, rows, msg_before=2)
+    finally:
+        routes.merge_session_messages_append_only = real_merge
+
+    assert merge_calls["n"] == 2, "msg_before paging must recompute, not reuse the tail entry"
+    assert [m.get("content") for m in paged] == [
+        "turn 0", "turn 1", "turn 2", "turn 3", "turn 4", "turn 5",
+        "state row 0", "state row 1",
+    ], "paged read must cover the uncapped merge scope"

--- a/tests/test_display_merge_cache_shortcut.py
+++ b/tests/test_display_merge_cache_shortcut.py
@@ -8,8 +8,12 @@ load entirely.
 That is only sound because the cache key no longer depends on the loaded rows.
 These tests pin the two properties that make the shortcut safe:
   1. a hit returns EXACTLY what the full load+merge path returns;
-  2. anything uncertain (active session, unbuildable key, changed data) falls
-     back to the full load rather than serving a stale transcript.
+  2. anything uncertain (active session without a registered in-process stream,
+     unbuildable key, changed data, expired streaming TTL) falls back to the
+     full load rather than serving a stale transcript. RC1 additionally pins
+     that an active session WITH a registered stream probes under the
+     freeze-marker key within the streaming TTL, and that msg_before paging
+     keeps bypassing the cache.
 """
 
 import sys
@@ -127,8 +131,14 @@ def test_shortcut_matches_the_full_merge_path(monkeypatch, stable_key):
 # Fail-closed: never serve a stale transcript.
 # --------------------------------------------------------------------------
 
-def test_active_stream_never_uses_the_cache(stable_key):
-    """An active session's in-memory tail can be ahead of its disk signature."""
+def test_unregistered_active_stream_never_uses_the_cache(stable_key):
+    """Fail-closed for a stream this process cannot see.
+
+    RC1 lets an in-process registered stream probe under the freeze marker, but
+    a cross-process (gateway/CLI) turn has no registered stream id here: the
+    in-memory tail cannot be verified against anything this process can build,
+    so the probe must refuse instead of serving a possibly stale transcript.
+    """
     session = _Session()
     sidecar = [{"role": "user", "content": "hi", "timestamp": 10.0}]
     _seed(session, sidecar, [{"role": "user", "content": "hi", "timestamp": 10.0}])
@@ -137,13 +147,75 @@ def test_active_stream_never_uses_the_cache(stable_key):
     assert routes._display_merge_cached_messages(session, sidecar) is None
 
 
-def test_pending_user_message_never_uses_the_cache(stable_key):
+def test_pending_user_message_without_registered_stream_never_uses_the_cache(stable_key):
+    """A queued user message is not part of the merge, but without a registered
+    in-process stream there is no freeze marker either — fail closed."""
     session = _Session()
     sidecar = [{"role": "user", "content": "hi", "timestamp": 10.0}]
     _seed(session, sidecar, [{"role": "user", "content": "hi", "timestamp": 10.0}])
 
     session.pending_user_message = {"content": "not yet on disk"}
     assert routes._display_merge_cached_messages(session, sidecar) is None
+
+
+def test_registered_active_stream_probes_the_streaming_cache(monkeypatch, stable_key):
+    """RC1: an active session with an in-process registered stream may hit the
+    memoized merge under the freeze-marker key, bounded by the streaming TTL."""
+    marker = ("streaming", ("stream-123",))
+    monkeypatch.setattr(routes, "_active_stream_ids", lambda: {"stream-123"})
+    now = [1000.0]
+    monkeypatch.setattr(routes.time, "monotonic", lambda: now[0])
+    session = _Session(active="stream-123")
+    sidecar = [{"role": "user", "content": "hi", "timestamp": 10.0}]
+    merged = [{"role": "user", "content": "hi", "timestamp": 10.0}]
+    key = routes._display_merge_cache_key(
+        session, sidecar, None, state_db_signature=marker)
+    assert key is not None
+    with routes._display_merge_cache_lock:
+        routes._display_merge_cache[session.session_id] = {
+            "key": key,
+            "messages": merged,
+            "stored_at": now[0],
+        }
+
+    now[0] += routes._DISPLAY_MERGE_STREAMING_TTL_SECONDS - 0.1
+    assert routes._display_merge_cached_messages(session, sidecar) == merged
+
+    now[0] += 0.2  # past the TTL
+    assert routes._display_merge_cached_messages(session, sidecar) is None
+
+
+def test_registered_active_stream_fills_the_entry_the_probe_hits(monkeypatch, stable_key):
+    """Fill and probe must agree for an active session: one merge, then hits."""
+    monkeypatch.setattr(routes, "_active_stream_ids", lambda: {"stream-123"})
+    session = _Session(active="stream-123")
+    sidecar = [{"role": "user", "content": "one", "timestamp": 1.0}]
+    rows = [
+        {"role": "user", "content": "one", "timestamp": 1.0},
+        {"role": "assistant", "content": "two", "timestamp": 2.0},
+    ]
+
+    merge_calls = {"n": 0}
+    real_merge = routes.merge_session_messages_append_only
+
+    def counting_merge(*args, **kwargs):
+        merge_calls["n"] += 1
+        return real_merge(*args, **kwargs)
+
+    routes.merge_session_messages_append_only = counting_merge
+    try:
+        filled = routes._limited_webui_messages_for_display_with_sidecar(
+            session, sidecar, rows)
+        probed = routes._display_merge_cached_messages(session, sidecar)
+    finally:
+        routes.merge_session_messages_append_only = real_merge
+
+    assert probed == filled, "probe must serve exactly what the fill memoized"
+    assert merge_calls["n"] == 1, "repeat tail load within the TTL re-ran the merge"
+    with routes._display_merge_cache_lock:
+        entry = routes._display_merge_cache.get(session.session_id)
+    assert entry is not None
+    assert entry["key"][4][0] == "streaming", "active fills must use the freeze marker"
 
 
 def test_live_memory_session_blocks_hit_from_stale_idle_object(stable_key):

--- a/tests/test_rc3_frontend_throttle.py
+++ b/tests/test_rc3_frontend_throttle.py
@@ -1,0 +1,307 @@
+"""rc3a + rc3b regression coverage.
+
+rc3a: the reasoning SSE handler must defer its thinking-card/anchor DOM write to
+the existing 15fps render scheduler (_scheduleRender/_doRender) instead of
+writing the card DOM once per event — the main-thread starvation measured in
+fase 6 (4258 reasoning events replayed on open of a tool-heavy active session).
+
+rc3b: the tool/tool_complete hot path must use the existing trailing throttles
+(_throttledSnapshotLiveTurn, _throttledPersist — WS2.2/WS2.3 contracts) instead
+of a synchronous whole-turn outerHTML snapshot and a whole-map synchronous
+localStorage persist per event. Terminal paths (done/cancel/stream_end) keep
+their synchronous finalize/cancel semantics.
+
+State layers mutated and invariant proven here: the reasoning accumulators
+(reasoningText/liveReasoningText) and INFLIGHT are still advanced synchronously
+per event, so no event content is dropped; only DOM writes and persistence
+latency move onto the already-accepted throttle contracts.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+MESSAGES_JS = ROOT / "static" / "messages.js"
+
+
+def _source(path: Path = MESSAGES_JS) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _head_source() -> str:
+    """Pre-rc3 baseline (messages.js is untouched by rc1/rc2, so HEAD == pre-rc3)."""
+    return subprocess.run(
+        ["git", "show", "HEAD:static/messages.js"],
+        cwd=ROOT, text=True, capture_output=True, check=True,
+    ).stdout
+
+
+def _extract_block(src: str, start_marker: str) -> str:
+    start = src.find(start_marker)
+    assert start >= 0, f"marker not found: {start_marker!r}"
+    depth = 0
+    started = False
+    i = start
+    while i < len(src):
+        ch = src[i]
+        if ch == "{":
+            depth += 1
+            started = True
+        elif ch == "}":
+            depth -= 1
+            if started and depth == 0:
+                return src[start:i + 1]
+        i += 1
+    raise AssertionError(f"unbalanced block at {start_marker!r}")
+
+
+def _event_listener(src: str, event: str) -> str:
+    return _extract_block(src, "source.addEventListener('" + event + "',e=>{")
+
+
+_PREAMBLE = r"""
+let __now = 0;
+let __frames = [];
+let __timers = [];
+const performance = { now: () => __now };
+function requestAnimationFrame(cb){ __frames.push(cb); return __frames.length; }
+function setTimeout(cb, ms){ __timers.push({cb: cb, at: __now + (ms || 0)}); return __timers.length; }
+function clearTimeout(t){ if(t && t <= __timers.length) __timers[t - 1].cb = null; }
+function __advance(ms){
+  const end = __now + ms;
+  while(__now < end){
+    __now += 1;
+    const frames = __frames.splice(0);
+    for(const f of frames) f();
+    for(const t of __timers) if(t.cb && __now >= t.at) { const cb = t.cb; t.cb = null; cb(); }
+  }
+}
+function __drainFrames(){ const frames = __frames.splice(0); for(const f of frames) f(); }
+"""
+
+_RC3A_REGION_START = "let _lastRenderMs=0;"
+
+
+def _rc3a_harness(src: str) -> str:
+    schedule = _extract_block(src, "function _scheduleRender(")
+    region_start = src.find(_RC3A_REGION_START)
+    assert region_start >= 0
+    helper_region = src[region_start:src.find("function _scheduleRender(")]
+    return helper_region + "\n" + schedule
+
+
+_RC3A_STUBS = r"""
+const S = { session: { session_id: 's1' }, activeStreamId: 'r1' };
+const activeSid = 's1', streamId = 'r1';
+let _streamFinalized = false;
+let _renderPending = false, _pendingRafHandle = null;
+let reasoningText = '', liveReasoningText = '', assistantText = '';
+let segmentStart = 0, assistantBody = null;
+let _isActiveSession = () => true;
+const window = { };
+let cardWrites = 0, anchorUpserts = 0;
+let __flushed = [];
+function _peekFlushed(){ return __flushed[__flushed.length-1] || null; }
+function _parseStreamState(){ return { displayText: '', thinkingText: liveReasoningText, inThinking: true }; }
+function _renderLiveThinking(parsed){ }
+function _liveThinkingText(){ return liveReasoningText; }
+function _upsertAnchorReasoning(text){ __flushed.push(text); anchorUpserts++; return true; }
+function _updateLiveThinkingCard(text){ cardWrites++; }
+function scrollIfPinned(){ }
+function _throttledSnapshotLiveTurn(){ }
+function _upsertAnchorProcessProse(){ }
+function _shouldUseLiveProseFade(){ return false; }
+function _stripXmlToolCalls(s){ return s; }
+"""
+
+_RC3B_PERSIST_REGION = r"""
+const events = { persist: 0, snapshot: 0, lastSaved: null };
+const S = { todos: [], todoStateMeta: null };
+const INFLIGHT = { s1: { messages: [{role:'assistant', content:'x', _live:true}], toolCalls: [{name:'terminal'}],
+                         uploaded: [], lastAssistantText: 'a'.repeat(9000),
+                         lastReasoningText: 'r'.repeat(177000) } };
+const activeSid = 's1', streamId = 'r1', uploaded = [];
+function saveInflightState(sid, state){ events.persist++; events.lastSaved = state; }
+function snapshotLiveTurnHtmlForSession(sid){ events.snapshot++; }
+"""
+
+_RC3B_BODY = r"""
+let coalesced = null;
+for(let i = 0; i < 198; i++){
+  INFLIGHT[activeSid].toolCalls.push({ name: 'terminal', done: true, tid: 't' + i });
+  _throttledPersist();
+  _throttledSnapshotLiveTurn();
+  __advance(100);
+}
+coalesced = { persist: events.persist, snapshot: events.snapshot };
+if(_persistTimer){ clearTimeout(_persistTimer); _persistTimer = null; }
+_cancelThrottledSnapshotTimer();
+const afterCancel = { persist: events.persist, snapshot: events.snapshot };
+__advance(5000);
+console.log(JSON.stringify({ coalesced: coalesced, afterCancel: afterCancel }));
+"""
+
+
+def _run_node(script: str, timeout: float = 30.0) -> dict:
+    result = subprocess.run(
+        ["node", "-e", script], cwd=ROOT, text=True, capture_output=True, timeout=timeout, check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+# ── rc3a static contract ─────────────────────────────────────────────────────
+
+def test_rc3a_reasoning_handler_defers_dom_write_to_render_frame():
+    src = _source()
+    handler = _event_listener(src, "reasoning")
+    assert "_updateLiveThinkingCard(" not in handler, "reasoning handler must not write the card DOM per event"
+    assert "_upsertAnchorReasoning(" not in handler, "reasoning handler must not touch anchor rows per event"
+    assert "_pendingReasoningDomFlush=true" in handler
+    assert "_scheduleRender()" in handler
+    assert "reasoningText += text" in handler
+    assert "liveReasoningText += text" in handler
+    assert "syncInflightAssistantMessage()" in handler
+
+
+def test_rc3a_flush_helper_runs_inside_do_render_before_thinking():
+    src = _source()
+    helper = _extract_block(src, "function _flushPendingReasoningDom(")
+    assert "_updateLiveThinkingCard(" in helper and "_upsertAnchorReasoning(" in helper
+    assert "if(_streamFinalized) return" in helper
+    do_render = _extract_block(src, "const _doRender=()=>{")
+    flush_at = do_render.find("_flushPendingReasoningDom();")
+    thinking_at = do_render.find("_renderLiveThinking(parsed);")
+    assert 0 < flush_at < thinking_at, "flush must run before the thinking render inside the frame"
+
+
+def test_rc3a_ordering_flushes_before_reasoning_accumulator_resets():
+    src = _source()
+    tool = _event_listener(src, "tool")
+    assert 0 < tool.find("_flushPendingReasoningDom();") < tool.find("liveReasoningText='';")
+    interim = _event_listener(src, "interim_assistant")
+    assert 0 < interim.find("_flushPendingReasoningDom();") < interim.find("liveReasoningText='';")
+
+
+# ── rc3b static contract ─────────────────────────────────────────────────────
+
+def test_rc3b_tool_hot_path_uses_throttled_snapshot_and_persist():
+    src = _source()
+    upsert = _extract_block(src, "function upsertLiveToolCall(")
+    assert "_throttledPersist();" in upsert
+    assert "persistInflightState();" not in upsert
+    for event in ("tool", "tool_complete"):
+        listener = _event_listener(src, event)
+        assert "_throttledSnapshotLiveTurn();" in listener, event
+        assert "snapshotLiveTurn();" not in listener, event
+
+
+def test_rc3b_terminal_paths_keep_synchronous_finalize_semantics():
+    src = _source()
+    for event in ("done", "cancel"):
+        listener = _event_listener(src, event)
+        assert "_cancelThrottledSnapshotTimer()" in listener, event
+        assert "_throttledSnapshotLiveTurn()" not in listener, event
+        assert "clearTimeout(_persistTimer)" in listener, event
+    # stream_end finalizes through _finalizeStreamEndFallback, which cancels both
+    # trailing timers synchronously before finalizing.
+    stream_end = _extract_block(src, "source.addEventListener('stream_end',async e=>{")
+    fallback = _extract_block(src, "function _finalizeStreamEndFallback(source){")
+    assert "_finalizeStreamEndFallback(" in stream_end or "_cancelThrottledSnapshotTimer()" in stream_end
+    assert "_cancelThrottledSnapshotTimer()" in fallback and "clearTimeout(_persistTimer)" in fallback
+    assert "_throttledSnapshotLiveTurn()" not in fallback
+
+
+# ── behavioral (virtual clock) ───────────────────────────────────────────────
+
+def test_rc3a_burst_reasoning_renders_at_frame_rate_not_event_rate():
+    """4258 reasoning events across a 40s virtual replay must produce
+    ~frame-rate card writes (<= 700) instead of one write per event (4258)."""
+    body = r"""
+for(let i = 0; i < 4258; i++){
+  const text = 'r' + i;
+  reasoningText += text;
+  liveReasoningText += text;
+  _pendingReasoningDomFlush = true;
+  _scheduleRender();
+  __advance(9);
+}
+__drainFrames(); __advance(200); __drainFrames();
+console.log(JSON.stringify({ cardWrites: cardWrites, anchorUpserts: anchorUpserts }));
+"""
+    after = _run_node(_PREAMBLE + _RC3A_STUBS + _rc3a_harness(_source()) + body)
+    assert after["anchorUpserts"] <= 700, after
+    assert after["anchorUpserts"] >= 1
+
+    before_body = body.replace(
+        "  _pendingReasoningDomFlush = true;\n  _scheduleRender();",
+        "  _updateLiveThinkingCard(liveReasoningText);",
+    )
+    # The pre-rc3 source has no _pendingReasoningDomFlush; strip it from the harness.
+    before_harness = _rc3a_harness(_head_source())
+    before = _run_node(_PREAMBLE + _RC3A_STUBS + before_harness + before_body)
+    assert before["cardWrites"] == 4258, before  # one full-card write per event: the starvation
+    assert before["anchorUpserts"] == 0, before
+
+
+def test_rc3a_no_reasoning_content_lost_and_tool_boundary_ordering_preserved():
+    body = r"""
+for(const chunk of ['alpha', 'beta', 'gamma']){
+  liveReasoningText += chunk;
+  _pendingReasoningDomFlush = true;
+  _scheduleRender();
+}
+// frame still pending here — the tool boundary must flush synchronously:
+_flushPendingReasoningDom();          // what the tool handler does first (sync)
+const flushedBySyncFlush = _peekFlushed();
+liveReasoningText = '';               // tool handler reset
+_flushPendingReasoningDom();          // must be a no-op now (flag consumed)
+__drainFrames(); __advance(100); __drainFrames();
+console.log(JSON.stringify({ flushedBySyncFlush: flushedBySyncFlush, flushCount: __flushed.length }));
+"""
+    script = _PREAMBLE + _RC3A_STUBS + _rc3a_harness(_source()) + body
+    payload = _run_node(script)
+    assert payload["flushedBySyncFlush"] == "alphabetagamma", payload  # no content lost
+    assert payload["flushCount"] == 1, payload                          # consumed exactly once
+
+
+def test_rc3b_throttled_snapshot_and_persist_coalesce_with_virtual_clock():
+    """198 tool events across 20s must coalesce into <= 11 persists and
+    <= 30 snapshots; the terminal cancel stops any pending timer."""
+    src = _source()
+    region_start = src.find("  function persistInflightState(){")
+    region_end = src.find("  function _closeSource(source){")
+    assert 0 < region_start < region_end, "persist/snapshot throttle region must be contiguous"
+    region = src[region_start:region_end]
+    script = _PREAMBLE + _RC3B_PERSIST_REGION + region + _RC3B_BODY
+    payload = _run_node(script)
+    assert payload["coalesced"]["persist"] <= 11, payload
+    assert payload["coalesced"]["snapshot"] <= 30, payload
+    assert payload["afterCancel"]["persist"] == payload["coalesced"]["persist"], payload
+    assert payload["afterCancel"]["snapshot"] == payload["coalesced"]["snapshot"], payload
+
+
+def test_rc3b_trailing_persist_writes_latest_state_within_contract_window():
+    src = _source()
+    region_start = src.find("  function persistInflightState(){")
+    region_end = src.find("  function _closeSource(source){")
+    region = src[region_start:region_end]
+    body = r"""
+INFLIGHT[activeSid].lastAssistantText = 't1';
+_throttledPersist();
+INFLIGHT[activeSid].lastAssistantText = 't2';
+_throttledPersist();
+__advance(2500);
+console.log(JSON.stringify({ savedLast: events.lastSaved ? events.lastSaved.lastAssistantText : null }));
+"""
+    payload = _run_node(_PREAMBLE + _RC3B_PERSIST_REGION + region + body)
+    assert payload["savedLast"] == "t2", payload
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_run_journal_incremental_read.py
+++ b/tests/test_run_journal_incremental_read.py
@@ -1,0 +1,364 @@
+"""RC2: the run journal read path must be incremental when continuity is proven.
+
+During a live turn the journal grows on every streamed event, so every summary
+invalidation forced a full re-read + re-parse of the whole file, and
+``_run_journal_live_snapshot`` paid it twice per request (``find_run_summary``
++ ``read_run_events``). The incremental read cache in ``_read_jsonl`` must:
+
+- return EXACTLY the historical rows (``_read_jsonl_legacy`` is the oracle);
+- reuse the parsed prefix only when the append-only watermark continuity is
+  verified (same inode, no shrink, byte-identical overlap before the watermark,
+  first new row continues ``seq == last_seq + 1`` with a consistent envelope);
+- fall back to the full read on any uncertainty (truncate, rotate, same-size
+  rewrite, seq gap, malformed first tail row, undecodable bytes);
+- treat a trailing partial line (writer mid-append) exactly like the historical
+  reader did for that read, without consuming it — no loss, no duplication;
+- keep ``find_run_summary``/``read_run_events`` results and shapes unchanged.
+"""
+
+import json
+
+import pytest
+
+from api import run_journal as RJ
+
+
+@pytest.fixture(autouse=True)
+def _clean_read_cache():
+    with RJ._JOURNAL_READ_CACHE_LOCK:
+        RJ._JOURNAL_READ_CACHE.clear()
+        for key in list(RJ._JOURNAL_READ_PATH_STATS):
+            RJ._JOURNAL_READ_PATH_STATS[key] = 0
+    yield
+    with RJ._JOURNAL_READ_CACHE_LOCK:
+        RJ._JOURNAL_READ_CACHE.clear()
+
+
+def _journal_path(tmp_path, session_id="session_1", run_id="run_1"):
+    return tmp_path / "_run_journal" / session_id / f"{run_id}.jsonl"
+
+
+def _append(session_dir, run_id="run_1", session_id="session_1", name="token", payload=None):
+    return RJ.append_run_event(session_id, run_id, name, payload or {"text": "x"}, session_dir=session_dir)
+
+
+def _stats():
+    with RJ._JOURNAL_READ_CACHE_LOCK:
+        return dict(RJ._JOURNAL_READ_PATH_STATS)
+
+
+# ---------------------------------------------------------------------------
+# Journal idle invariato: zero re-parse, risultato identico.
+# ---------------------------------------------------------------------------
+
+def test_idle_journal_repeated_reads_are_identical_and_zero_parse(tmp_path):
+    _append(tmp_path, payload={"text": "uno"})
+    _append(tmp_path, name="done", payload={"session": {}})
+
+    first = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    assert [event["seq"] for event in first["events"]] == [1, 2]
+
+    stats_before = _stats()
+    for _ in range(4):
+        repeated = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+        assert repeated == first
+    stats_after = _stats()
+    assert stats_after["fast"] > stats_before["fast"], "unchanged journal must hit the watermark fast path"
+    assert stats_after["full"] == stats_before["full"], "unchanged journal must never re-read from disk"
+
+
+def test_idle_summary_reuse_and_find_run_summary_shape(tmp_path):
+    _append(tmp_path, payload={"text": "uno"})
+    _append(tmp_path, name="done", payload={"session": {}})
+
+    first = RJ.find_run_summary("run_1", session_dir=tmp_path)
+    assert first["session_id"] == "session_1"
+    assert first["event_count"] == 2
+    assert first["last_seq"] == 2
+    assert first["terminal_state"] == "completed"
+    assert first["path"].endswith("run_1.jsonl")
+    again = RJ.find_run_summary("run_1", session_dir=tmp_path)
+    assert again == first
+
+
+# ---------------------------------------------------------------------------
+# Journal durante streaming: append + letture consecutive, nessuna perdita
+# o duplicazione, parità con la lettura full da zero.
+# ---------------------------------------------------------------------------
+
+def test_streaming_appends_are_read_incrementally_without_loss_or_duplication(tmp_path):
+    for _ in range(3):
+        _append(tmp_path)
+    first = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    assert [event["seq"] for event in first["events"]] == [1, 2, 3]
+    assert _stats()["full"] == 1 and _stats()["tail"] == 0
+
+    for _ in range(4):
+        _append(tmp_path)
+    second = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    seqs = [event["seq"] for event in second["events"]]
+    assert seqs == [1, 2, 3, 4, 5, 6, 7], "append-only growth must extend, never duplicate"
+    assert _stats()["tail"] >= 1, "grown journal must parse only its tail"
+    assert _stats()["full"] == 1, "verified append continuity must not force a full re-read"
+
+    # Oracle: a cold full read of the same file must return exactly the same rows.
+    with RJ._JOURNAL_READ_CACHE_LOCK:
+        RJ._JOURNAL_READ_CACHE.clear()
+    oracle = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    assert [event["event_id"] for event in oracle["events"]] == [
+        event["event_id"] for event in second["events"]
+    ]
+    assert oracle["events"] == second["events"]
+
+
+def test_consecutive_requests_during_one_stream_stay_contiguous(tmp_path):
+    expected = []
+    for turn in range(5):
+        event = _append(tmp_path, payload={"text": f"tok{turn}"})
+        expected.append(event["seq"])
+        journal = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+        assert [e["seq"] for e in journal["events"]] == expected
+        summary = RJ.find_run_summary("run_1", session_dir=tmp_path)
+        assert summary["event_count"] == len(expected)
+        assert summary["last_seq"] == expected[-1]
+        assert summary["terminal"] is False
+    assert _stats()["full"] == 1, "only the cold read may parse the whole file"
+
+
+def test_summary_and_read_agree_after_appends(tmp_path):
+    _append(tmp_path)
+    RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    _append(tmp_path, name="done", payload={"session": {}})
+    summary = RJ.find_run_summary("run_1", session_dir=tmp_path)
+    assert summary["terminal"] is True and summary["terminal_state"] == "completed"
+    assert summary["event_count"] == 2
+    journal = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    assert journal["events"][-1]["event"] == "done"
+
+
+def test_read_run_events_filters_over_cached_rows(tmp_path):
+    for _ in range(4):
+        _append(tmp_path)
+    RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)  # warm cache
+    _append(tmp_path)
+    journal = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path, after_seq=2, max_seq=4)
+    assert [event["seq"] for event in journal["events"]] == [3, 4]
+
+
+def test_next_seq_seeding_uses_cached_rows_without_reparsing(tmp_path):
+    _append(tmp_path)
+    RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    event = _append(tmp_path)  # seeds/reserves via the same read cache
+    assert event["seq"] == 2
+    journal = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    assert [event["seq"] for event in journal["events"]] == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# Ultima riga parziale: riportata come la lettura storica, mai consumata.
+# ---------------------------------------------------------------------------
+
+def test_partial_last_line_is_reported_then_parsed_once_when_complete(tmp_path):
+    _append(tmp_path)
+    path = _journal_path(tmp_path)
+    first = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    assert [event["seq"] for event in first["events"]] == [1]
+
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write('{"version":1,"seq":2,"run_id":"run_1","session_id":"session_1","event":"tok')
+
+    during = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    legacy_during = RJ._read_jsonl_legacy(path)
+    assert during["events"] == legacy_during[0], "partial fragment must be handled like the historical reader"
+    assert during["malformed"] == legacy_during[1]
+    assert len(during["events"]) == 1
+    assert len(during["malformed"]) == 1 and during["malformed"][0]["line"] == 2
+
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write('","payload":{"text":"fin"}}\n')
+
+    completed = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    assert [event["seq"] for event in completed["events"]] == [1, 2], "completed line parsed exactly once"
+    assert completed["malformed"] == [], "transient malformed row must disappear once the line completes"
+
+    legacy = RJ._read_jsonl_legacy(path)
+    assert completed["events"] == legacy[0] and completed["malformed"] == legacy[1]
+
+
+def test_partial_line_that_stays_partial_never_leaks_into_cache(tmp_path):
+    _append(tmp_path)
+    path = _journal_path(tmp_path)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write('{"torn":')
+    for _ in range(3):
+        journal = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+        assert [event["seq"] for event in journal["events"]] == [1]
+        assert len(journal["malformed"]) == 1
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write('1}\n')
+    # The completed torn row is valid JSON ("{"torn":1}), so it becomes a row:
+    # it must appear exactly once (no duplication of the transient fragment).
+    journal = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    assert sum(1 for e in journal["events"] if e.get("torn") == 1) == 1
+    legacy = RJ._read_jsonl_legacy(path)
+    assert journal["events"] == legacy[0] and journal["malformed"] == legacy[1]
+
+
+# ---------------------------------------------------------------------------
+# Fallback a full read: ogni incertezza deve tornare al percorso storico.
+# ---------------------------------------------------------------------------
+
+def test_truncated_journal_falls_back_and_returns_shrunk_content(tmp_path):
+    _append(tmp_path)
+    _append(tmp_path)
+    path = _journal_path(tmp_path)
+    assert len(RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)["events"]) == 2
+
+    original = path.read_bytes()
+    path.write_bytes(original[: len(original) // 2])  # same inode, shrunk
+
+    stats_before = _stats()
+    shrunk = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    assert _stats()["full"] > stats_before["full"], "shrink must fall back to the full read"
+    assert len(shrunk["events"]) <= 2
+    legacy = RJ._read_jsonl_legacy(path)
+    assert shrunk["events"] == legacy[0] and shrunk["malformed"] == legacy[1]
+
+
+def test_rotated_journal_new_inode_falls_back_to_full_read(tmp_path):
+    _append(tmp_path, run_id="run_1")
+    path = _journal_path(tmp_path, run_id="run_1")
+    assert len(RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)["events"]) == 1
+
+    # Rotation = delete + recreate with fresh content (new inode).
+    path.unlink()
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps({
+            "version": 1, "event_id": "run_1:1", "seq": 1, "run_id": "run_1",
+            "session_id": "session_1", "event": "done", "type": "done",
+            "created_at": 1.0, "terminal": True, "terminal_state": "completed",
+            "payload": {},
+        }) + "\n")
+
+    stats_before = _stats()
+    rotated = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    assert _stats()["full"] > stats_before["full"], "new inode must fall back to the full read"
+    assert [event["event"] for event in rotated["events"]] == ["done"]
+
+
+def test_same_size_rewrite_falls_back_to_full_read(tmp_path):
+    _append(tmp_path, payload={"text": "aaaa"})
+    path = _journal_path(tmp_path)
+    assert len(RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)["events"]) == 1
+
+    # Same inode, same size, different bytes (and advanced ctime).
+    content = path.read_bytes()
+    replaced = content.replace(b'"aaaa"', b'"bbbb"')
+    assert len(replaced) == len(content)
+    path.write_bytes(replaced)
+
+    stats_before = _stats()
+    rewritten = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    assert _stats()["full"] > stats_before["full"], "same-size rewrite must fall back"
+    assert rewritten["events"][0]["payload"]["text"] == "bbbb"
+
+
+def test_seq_gap_in_tail_falls_back_but_keeps_rows(tmp_path):
+    _append(tmp_path)
+    path = _journal_path(tmp_path)
+    assert len(RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)["events"]) == 1
+
+    gap_row = {
+        "version": 1, "event_id": "run_1:5", "seq": 5, "run_id": "run_1",
+        "session_id": "session_1", "event": "token", "type": "token",
+        "created_at": 2.0, "terminal": False, "terminal_state": None,
+        "payload": {"text": "gap"},
+    }
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(gap_row) + "\n")
+
+    stats_before = _stats()
+    journal = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    assert _stats()["full"] > stats_before["full"], "seq gap must fall back to the full read"
+    assert [event["seq"] for event in journal["events"]] == [1, 5], "fallback must not drop rows"
+
+
+def test_malformed_first_tail_row_falls_back_to_full_read(tmp_path):
+    _append(tmp_path)
+    path = _journal_path(tmp_path)
+    RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write("{not json}\n")
+
+    stats_before = _stats()
+    journal = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    assert _stats()["full"] > stats_before["full"]
+    assert len(journal["events"]) == 1 and len(journal["malformed"]) == 1
+
+
+def test_undecodable_tail_falls_back_to_full_read_like_history(tmp_path):
+    _append(tmp_path)
+    path = _journal_path(tmp_path)
+    RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    with path.open("ab") as fh:
+        fh.write(b"\xff\xfe\n")
+
+    legacy_exc = None
+    try:
+        RJ._read_jsonl_legacy(path)
+    except UnicodeDecodeError as exc:  # historical behavior: the decode error propagates
+        legacy_exc = exc
+    assert legacy_exc is not None
+    with pytest.raises(UnicodeDecodeError):
+        RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+
+
+def test_exotic_line_break_parity_with_historical_reader(tmp_path):
+    _append(tmp_path)
+    path = _journal_path(tmp_path)
+    RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    # A raw U+2028 inside a payload splits under str.splitlines(): the
+    # incremental reader must reproduce the historical (malformed) rows, not
+    # silently become more lenient.
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps({"version": 1, "seq": 2, "event": "token"}, ensure_ascii=False) + "\n")
+
+    journal = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    legacy = RJ._read_jsonl_legacy(path)
+    assert journal["events"] == legacy[0]
+    assert journal["malformed"] == legacy[1]
+
+
+# ---------------------------------------------------------------------------
+# Cache fredda / nuovo processo: la prima lettura è full e corretta.
+# ---------------------------------------------------------------------------
+
+def test_cold_cache_first_read_is_full_and_correct(tmp_path):
+    for _ in range(3):
+        _append(tmp_path)
+    stats_before = _stats()
+    journal = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    assert _stats()["full"] == stats_before["full"] + 1
+    assert [event["seq"] for event in journal["events"]] == [1, 2, 3]
+
+
+def test_cache_is_per_path_and_isolated(tmp_path):
+    _append(tmp_path, run_id="run_1")
+    _append(tmp_path, run_id="run_2")
+    first = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    second = RJ.read_run_events("session_1", "run_2", session_dir=tmp_path)
+    _append(tmp_path, run_id="run_1")
+    _append(tmp_path, run_id="run_2")
+    first = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    second = RJ.read_run_events("session_1", "run_2", session_dir=tmp_path)
+    assert [event["seq"] for event in first["events"]] == [1, 2]
+    assert [event["seq"] for event in second["events"]] == [1, 2]
+    assert first["run_id"] == "run_1" and second["run_id"] == "run_2"
+
+
+def test_missing_journal_reads_empty_and_cache_stays_clean(tmp_path):
+    journal = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    assert journal["events"] == [] and journal["malformed"] == []
+    _append(tmp_path)
+    journal = RJ.read_run_events("session_1", "run_1", session_dir=tmp_path)
+    assert [event["seq"] for event in journal["events"]] == [1]


### PR DESCRIPTION
Three independent fixes addressing slow chat loading and streaming jank on
long sessions. Rebased onto `master` at `exp-v0.52.297`; all touched tests
pass (`58 passed in 19.80s`).

## RC1 — `api/routes.py`: display-merge cache covers active sessions

Previously the memoized sidecar↔state.db merge was bypassed entirely for
active sessions (an in-memory tail could be ahead of the on-disk signature).
This adds a streaming freeze marker keyed on the set of in-process active
stream ids, with a 5-second TTL. Cross-process (gateway/CLI) turns remain
fail-closed: no registered stream → no cache. `msg_before` paging still
bypasses the cache to preserve the uncapped read scope.

## RC2 — `api/run_journal.py`: incremental JSONL read cache

`_read_jsonl` was re-parsing the whole journal on every streamed event.
This adds an append-only incremental reader that:
- verifies file identity (`st_dev`, `st_ino`) and append-only overlap before
  the byte watermark
- checks seq continuity on the first new row (`seq == last_seq + 1` and
  `event_id == f"{run_id}:{seq}"`)
- falls back to the full read on any uncertainty (shrink, rewrite, metadata
  change, overlap mismatch, malformed first row, undecodable bytes)

Partial trailing lines are reported for the current read but left unconsumed
so the completed line is parsed exactly once later. A `_read_jsonl_legacy`
function is kept as a parity oracle for tests.

## RC3 — `static/messages.js`: main-thread starvation fixes

- **RC3a**: reasoning SSE events no longer rebuild the thinking card and
  anchor rows per event. The accumulators update synchronously; the DOM
  write is deferred to the render frame. Removes the per-event forced
  layout on tool-heavy replay bursts.
- **RC3b**: inflight state persistence and live-turn snapshots are
  throttled (trailing 2s) instead of running synchronously on every
  tool/tool_complete SSE event. Terminal paths flush synchronously, so
  at most 2s of tool state can be lost on a crash.

## Tests

- `tests/test_display_merge_cache.py` — RC1 fail-closed cases + streaming
  cache reuse + TTL expiry + msg_before bypass
- `tests/test_display_merge_cache_shortcut.py` — RC1 fill/probe agreement
- `tests/test_run_journal_incremental_read.py` — RC2 parity against
  `_read_jsonl_legacy`, partial lines, malformed rows, exotic breaks
- `tests/test_rc3_frontend_throttle.py` — RC3 frontend throttle contract

## Notes

- Termux-compatible: no new runtime deps.
- All caches are bounded (`_DISPLAY_MERGE_CACHE_MAX=16`,
  `_JOURNAL_READ_CACHE_MAX_ENTRIES=4`,
  `_JOURNAL_READ_CACHE_MAX_TOTAL_BYTES=32MiB`) with LRU eviction.
- Fail-closed by construction: any uncertainty falls back to the full
  load/parse path, which returns exactly the historical result.

Fixes the streaming-session slowness observed on long transcripts.