### PR TITLE
fix: constrain session title generation to JSON and reject reasoning traces

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3777,6 +3777,9 @@ def _strip_xml_tool_calls(text: str) -> str:
     return s.strip()
 
 
+_MAX_GENERATED_TITLE_WORDS = 12
+
+
 def _sanitize_generated_title(text: str) -> str:
     """Sanitize LLM-generated title text before persisting to session."""
     s = _strip_thinking_markup(text or '')
@@ -3787,10 +3790,14 @@ def _sanitize_generated_title(text: str) -> str:
         flags=re.IGNORECASE,
     )
     s = re.sub(r'^\s*title\s*:\s*', '', s, flags=re.IGNORECASE)
-    s = s.strip(" \t\r\n\"'`*_~")
+    # Check the untrimmed candidate first so wrapping quotes remain available
+    # to the quoted-alternatives guard below.
+    if _looks_invalid_generated_title(s):
+        return ''
+    s = s.strip().strip("\"'`*_~").strip()
     s = re.sub(r'\s+', ' ', s).strip()
     # Guard against chain-of-thought leakage, meta-reasoning, and trivial echo.
-    if _is_bad_new_title(s):
+    if _is_bad_new_title(s) or len(s.split()) > _MAX_GENERATED_TITLE_WORDS:
         return ''
     return s[:80]
 
@@ -3807,6 +3814,18 @@ def _looks_invalid_generated_title(text: str) -> bool:
         return True
     return bool(
         re.search(r'<think>|<\|channel\|>thought|<\|turn\|>thinking', s, flags=re.IGNORECASE)
+        or re.search(
+            r'^\s*(?:[*_`~]+\s*)?(?:title should|something like|good title|a good title|options\s*:|maybe\s+)',
+            s,
+            flags=re.IGNORECASE,
+        )
+        or re.search(r'\b3-8 words\b|\btopic label\b', s, flags=re.IGNORECASE)
+        or re.search(
+            r'["“][^"”\n]+["”]\s+or\s+["“][^"”\n]+["”]',
+            s,
+            flags=re.IGNORECASE,
+        )
+        or re.search(r'^\s*[-*•]\s*["“][^"”\n]+["”]', s)
         or re.search(r'^\s*(the|ther)\s+user\s+', s, flags=re.IGNORECASE)
         or re.search(r'^\s*user\s+\w+\s+', s, flags=re.IGNORECASE)
         or re.search(r'\b(they|user)\s+want(s)?\s+me\s+to\b', s, flags=re.IGNORECASE)
@@ -4496,6 +4515,45 @@ def _safe_text_value(value) -> str:
     return str(value or '').strip()
 
 
+_TITLE_RESPONSE_FORMAT = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "session_title",
+        "strict": True,
+        "schema": {
+            "type": "object",
+            "properties": {"title": {"type": "string"}},
+            "required": ["title"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+def _extract_title_text(content: str) -> str:
+    """Extract a title from strict, fenced, or loosely embedded JSON."""
+    raw = str(content or '').strip()
+    if not raw:
+        return ''
+    fenced = re.match(r'^```(?:json)?\s*(.*?)\s*```$', raw, flags=re.IGNORECASE | re.DOTALL)
+    if fenced:
+        raw = fenced.group(1).strip()
+    try:
+        parsed = json.loads(raw)
+        if isinstance(parsed, dict) and isinstance(parsed.get('title'), str):
+            return parsed['title'].strip()
+        return ''
+    except (TypeError, ValueError):
+        pass
+    match = re.search(r'"title"\s*:\s*"((?:[^"\\]|\\.)*)"', raw)
+    if match:
+        try:
+            return json.loads(f'"{match.group(1)}"').strip()
+        except ValueError:
+            return match.group(1).strip()
+    return raw
+
+
 def _extract_title_response(resp, *, aux: bool = False) -> tuple[str, str]:
     """Return (content, empty_status) from an OpenAI-compatible response."""
     suffix = '_aux' if aux else ''
@@ -4505,7 +4563,9 @@ def _extract_title_response(resp, *, aux: bool = False) -> tuple[str, str]:
         message = _safe_obj_value(choice, 'message')
         content = _safe_text_value(_safe_obj_value(message, 'content'))
         if content:
-            return content, ''
+            title_text = _extract_title_text(content)
+            if title_text:
+                return title_text, ''
         finish_reason = _safe_text_value(_safe_obj_value(choice, 'finish_reason')).lower()
         reasoning = (
             _safe_text_value(_safe_obj_value(message, 'reasoning'))
@@ -4560,6 +4620,7 @@ def generate_title_raw_via_aux(
     if not caller_supplied_route:
         api_key = str(configured.get('api_key', '') or '').strip()
     base_max_tokens = _title_completion_budget(provider, model, base_url)
+    schema_extra = {"response_format": _TITLE_RESPONSE_FORMAT}
     reasoning_extra = {}
     if not _route_rejects_reasoning_extra(provider, model, base_url):
         reasoning_extra["reasoning"] = {"enabled": False}
@@ -4569,6 +4630,8 @@ def generate_title_raw_via_aux(
         _timeout = _aux_title_timeout()
         from agent.auxiliary_client import call_llm
         last_status = 'llm_error_aux'
+        attempted = 0
+        schema_unavailable = False
         for idx, prompt in enumerate(prompts):
             messages = [
                 {"role": "system", "content": prompt},
@@ -4577,22 +4640,37 @@ def generate_title_raw_via_aux(
             budgets = [base_max_tokens]
             try:
                 for budget_idx, max_tokens in enumerate(budgets):
-                    resp = call_llm(
-                        task='title_generation',
-                        provider=provider or None,
-                        model=model or None,
-                        base_url=base_url or None,
-                        api_key=api_key or None,
-                        messages=messages,
-                        max_tokens=max_tokens,
-                        temperature=0.2,
-                        timeout=_timeout,
-                        extra_body=reasoning_extra or None,
-                    )
-                    raw, empty_status = _extract_title_response(resp, aux=True)
-                    if raw:
-                        return raw, ('llm_aux' if idx == 0 and budget_idx == 0 else 'llm_aux_retry')
-                    last_status = empty_status or 'llm_empty_aux'
+                    modes = ('compatibility',) if schema_unavailable else ('schema', 'compatibility')
+                    for mode in modes:
+                        try:
+                            attempted += 1
+                            resp = call_llm(
+                                task='title_generation',
+                                provider=provider or None,
+                                model=model or None,
+                                base_url=base_url or None,
+                                api_key=api_key or None,
+                                messages=messages,
+                                max_tokens=max_tokens,
+                                temperature=0.2,
+                                timeout=_timeout,
+                                extra_body=(schema_extra if mode == 'schema' else (reasoning_extra or None)),
+                            )
+                        except Exception as e:
+                            last_status = 'llm_error_aux'
+                            if mode == 'schema':
+                                schema_unavailable = True
+                                logger.debug("Aux title schema attempt %s failed: %s", idx + 1, e)
+                                continue
+                            raise
+                        raw, empty_status = _extract_title_response(resp, aux=True)
+                        if raw:
+                            return raw, ('llm_aux' if attempted == 1 else 'llm_aux_retry')
+                        last_status = empty_status or 'llm_empty_aux'
+                        if mode == 'schema' and last_status == 'llm_empty_aux':
+                            schema_unavailable = True
+                            continue
+                        break
                     if budget_idx == 0 and _title_retry_status(last_status):
                         budgets.append(_title_retry_completion_budget(provider, model, base_url))
             except Exception as e:
@@ -4687,6 +4765,7 @@ def generate_title_raw_via_agent(agent, user_text: str, assistant_text: str) -> 
                         # (#4161). MiniMax still needs reasoning_split, which the
                         # profile path does not add.
                         _tg_extra = dict(api_kwargs.get('extra_body') or {})
+                        _tg_extra['response_format'] = _TITLE_RESPONSE_FORMAT
                         if _is_minimax_route(getattr(agent, 'provider', ''), getattr(agent, 'model', ''), getattr(agent, 'base_url', '')):
                             _tg_extra['reasoning_split'] = True
                         if _tg_extra:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4794,6 +4794,9 @@ def generate_title_raw_via_agent(agent, user_text: str, assistant_text: str) -> 
                                     continue
                                 raise
                             raw, empty_status = _extract_title_response(resp)
+                            if mode == 'schema' and empty_status in {'llm_empty', 'llm_empty_reasoning'}:
+                                schema_unavailable = True
+                                continue
                             break
                     raw = str(raw or '').strip()
                     if raw:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4667,7 +4667,7 @@ def generate_title_raw_via_aux(
                         if raw:
                             return raw, ('llm_aux' if attempted == 1 else 'llm_aux_retry')
                         last_status = empty_status or 'llm_empty_aux'
-                        if mode == 'schema' and last_status == 'llm_empty_aux':
+                        if mode == 'schema' and last_status in {'llm_empty_aux', 'llm_empty_reasoning_aux'}:
                             schema_unavailable = True
                             continue
                         break
@@ -4708,6 +4708,8 @@ def generate_title_raw_via_agent(agent, user_text: str, assistant_text: str) -> 
     prev_reasoning = getattr(agent, 'reasoning_config', None)
     try:
         agent.reasoning_config = disabled_reasoning
+        attempted = 0
+        schema_unavailable = False
         for idx, prompt in enumerate(prompts):
             api_messages = [
                 {"role": "system", "content": prompt},
@@ -4720,6 +4722,7 @@ def generate_title_raw_via_agent(agent, user_text: str, assistant_text: str) -> 
                     raw = ""
                     empty_status = ''
                     if getattr(agent, 'api_mode', '') == 'codex_responses':
+                        attempted += 1
                         codex_kwargs = agent._build_api_kwargs(api_messages)
                         codex_kwargs.pop('tools', None)
                         if 'max_output_tokens' in codex_kwargs:
@@ -4730,6 +4733,7 @@ def generate_title_raw_via_agent(agent, user_text: str, assistant_text: str) -> 
                         if not raw:
                             empty_status = 'llm_empty'
                     elif getattr(agent, 'api_mode', '') == 'anthropic_messages':
+                        attempted += 1
                         from agent.anthropic_adapter import build_anthropic_kwargs
                         ant_kwargs = build_anthropic_kwargs(
                             model=agent.model,
@@ -4749,10 +4753,10 @@ def generate_title_raw_via_agent(agent, user_text: str, assistant_text: str) -> 
                         if not raw:
                             empty_status = 'llm_empty'
                     else:
-                        api_kwargs = agent._build_api_kwargs(api_messages)
-                        api_kwargs.pop('tools', None)
-                        api_kwargs['temperature'] = 0.1
-                        api_kwargs['timeout'] = 15.0
+                        base_api_kwargs = agent._build_api_kwargs(api_messages)
+                        base_api_kwargs.pop('tools', None)
+                        base_api_kwargs['temperature'] = 0.1
+                        base_api_kwargs['timeout'] = 15.0
                         # Reasoning suppression for title gen is already handled
                         # route-correctly by `_build_api_kwargs()` from the
                         # `agent.reasoning_config = {"enabled": False}` set above —
@@ -4764,23 +4768,36 @@ def generate_title_raw_via_agent(agent, user_text: str, assistant_text: str) -> 
                         # re-adds a 400-rejected param on top of the profile output
                         # (#4161). MiniMax still needs reasoning_split, which the
                         # profile path does not add.
-                        _tg_extra = dict(api_kwargs.get('extra_body') or {})
-                        _tg_extra['response_format'] = _TITLE_RESPONSE_FORMAT
-                        if _is_minimax_route(getattr(agent, 'provider', ''), getattr(agent, 'model', ''), getattr(agent, 'base_url', '')):
-                            _tg_extra['reasoning_split'] = True
-                        if _tg_extra:
-                            api_kwargs['extra_body'] = _tg_extra
-                        if 'max_completion_tokens' in api_kwargs:
-                            api_kwargs['max_completion_tokens'] = max_tokens
-                        else:
-                            api_kwargs['max_tokens'] = max_tokens
-                        resp = agent._ensure_primary_openai_client(reason='title_generation').chat.completions.create(
-                            **api_kwargs,
-                        )
-                        raw, empty_status = _extract_title_response(resp)
+                        modes = ('compatibility',) if schema_unavailable else ('schema', 'compatibility')
+                        for mode in modes:
+                            api_kwargs = dict(base_api_kwargs)
+                            _tg_extra = dict(base_api_kwargs.get('extra_body') or {})
+                            if mode == 'schema':
+                                _tg_extra['response_format'] = _TITLE_RESPONSE_FORMAT
+                            if _is_minimax_route(getattr(agent, 'provider', ''), getattr(agent, 'model', ''), getattr(agent, 'base_url', '')):
+                                _tg_extra['reasoning_split'] = True
+                            if _tg_extra:
+                                api_kwargs['extra_body'] = _tg_extra
+                            if 'max_completion_tokens' in api_kwargs:
+                                api_kwargs['max_completion_tokens'] = max_tokens
+                            else:
+                                api_kwargs['max_tokens'] = max_tokens
+                            try:
+                                attempted += 1
+                                resp = agent._ensure_primary_openai_client(reason='title_generation').chat.completions.create(
+                                    **api_kwargs,
+                                )
+                            except Exception as e:
+                                if mode == 'schema':
+                                    schema_unavailable = True
+                                    logger.debug("Agent title schema attempt %s failed: %s", idx + 1, e)
+                                    continue
+                                raise
+                            raw, empty_status = _extract_title_response(resp)
+                            break
                     raw = str(raw or '').strip()
                     if raw:
-                        return raw, ('llm' if idx == 0 and budget_idx == 0 else 'llm_retry')
+                        return raw, ('llm' if attempted == 1 else 'llm_retry')
                     last_status = empty_status or 'llm_empty'
                     if budget_idx == 0 and _title_retry_status(last_status):
                         budgets.append(_title_retry_completion_budget(

--- a/docs/advanced-chat-setup.md
+++ b/docs/advanced-chat-setup.md
@@ -72,6 +72,14 @@ manually titled. Image-only or metadata-only content does not provide title
 text. Existing manual-title protection and the title-generation setting still
 apply; this cleanup does not rewrite the transcript or native image parts.
 
+Title-model requests prefer a strict JSON object containing a string `title`.
+OpenAI-compatible routes that reject the schema, return empty content, or emit
+reasoning without a title are retried once with the route's compatibility
+request shape. Generated candidates are unwrapped from common JSON containers
+and rejected rather than truncated when they resemble reasoning/meta commentary
+or exceed twelve words; rejected candidates fall through to the existing title
+retry or local-summary behavior.
+
 Automatic title-generation LLM calls honor the active Hermes profile's
 `auxiliary.title_generation.enabled` setting (default: `true`):
 

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -487,10 +487,12 @@ class TestReasoningModelTitleGeneration(unittest.TestCase):
         fallback path instead."""
         from api.streaming import generate_title_raw_via_aux
 
-        call_count = [0]
+        calls = []
 
         def fake_call_llm(**kwargs):
-            call_count[0] += 1
+            calls.append(kwargs)
+            if 'response_format' in (kwargs.get('extra_body') or {}):
+                raise ValueError('response_format unsupported')
             return {
                 'choices': [
                     {
@@ -509,9 +511,10 @@ class TestReasoningModelTitleGeneration(unittest.TestCase):
 
         self.assertIsNone(result)
         self.assertEqual(status, 'llm_empty_reasoning_aux')
-        # One call per prompt at the base budget — no retry on prompt 0, no
-        # second-prompt attempt either (short-circuited).
-        self.assertEqual(call_count[0], 1)
+        # The schema probe is rejected, then the reasoning-disabled compatibility
+        # call short-circuits without a larger budget or second-prompt attempt.
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[1]['extra_body'], {'reasoning': {'enabled': False}})
 
     def test_aux_still_retries_finish_length_without_reasoning(self):
         """Length-truncated responses WITHOUT reasoning tokens still get the

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -607,8 +607,10 @@ class TestReasoningModelTitleGeneration(unittest.TestCase):
 
         self.assertIsNone(result)
         self.assertEqual(status, 'llm_empty_reasoning')
-        # One call per prompt at base budget — no retry, no second-prompt attempt.
-        self.assertEqual(call_count[0], 1)
+        # The schema response gets one compatibility attempt. Reasoning-only
+        # compatibility output then short-circuits without a larger budget or
+        # second-prompt attempt.
+        self.assertEqual(call_count[0], 2)
         self.assertIsNone(agent.reasoning_config)
 
     def test_agent_route_still_retries_finish_length_without_reasoning(self):

--- a/tests/test_title_reasoning_trace_guard.py
+++ b/tests/test_title_reasoning_trace_guard.py
@@ -300,3 +300,56 @@ def test_agent_schema_rejection_falls_back_to_existing_request_shape():
     assert len(calls) == 2
     assert calls[1]["extra_body"] == {"reasoning_split": True}
     assert agent.reasoning_config is None
+
+
+@pytest.mark.parametrize(
+    "schema_response",
+    (
+        _response(""),
+        {
+            "choices": [
+                {
+                    "message": {"content": "", "reasoning": "hidden reasoning"},
+                    "finish_reason": "length",
+                }
+            ]
+        },
+    ),
+)
+def test_agent_empty_schema_response_tries_compatibility_shape(schema_response):
+    calls = []
+
+    def fake_create(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            return schema_response
+        return _response("Compatibility After Empty Schema")
+
+    client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=fake_create))
+    )
+    agent = MagicMock()
+    agent.api_mode = "openai"
+    agent.provider = "custom"
+    agent.model = "reasoning-gateway"
+    agent.base_url = "https://reasoning.example/v1"
+    agent.reasoning_config = None
+    agent._build_api_kwargs.side_effect = lambda messages: {
+        "messages": messages,
+        "extra_body": {"reasoning_effort": "none"},
+    }
+    agent._ensure_primary_openai_client.return_value = client
+
+    result, status = streaming.generate_title_raw_via_agent(
+        agent,
+        "Why is the schema response empty?",
+        "Compatibility mode can still return a title.",
+    )
+
+    assert result == "Compatibility After Empty Schema"
+    assert status == "llm_retry"
+    assert len(calls) == 2
+    assert calls[1]["messages"] == calls[0]["messages"]
+    assert calls[1]["max_tokens"] == calls[0]["max_tokens"]
+    assert calls[1]["extra_body"] == {"reasoning_effort": "none"}
+    assert agent.reasoning_config is None

--- a/tests/test_title_reasoning_trace_guard.py
+++ b/tests/test_title_reasoning_trace_guard.py
@@ -1,0 +1,238 @@
+"""Regression coverage for reasoning-trace leakage in WebUI session titles."""
+
+from contextlib import nullcontext
+import threading
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import api.streaming as streaming
+from tests._aux_client_helpers import auxiliary_client_modules, patch_tg_config
+
+
+BAD_TITLE_OUTPUTS = (
+    "Title should be 3-8 words, matching the user's language (English), topic label s…",
+    'Something like "Fix Session Title Generation" or "Audit Session Title Generation…',
+    'Good title: "Budget 2-Stage Snow Blower Recommendations" or "Cheapest Well-Revie…',
+    'Options: - "Durable Bathroom Flooring Options" - "Cost-Effective Bathroom Floor…',
+)
+
+EXPECTED_RESPONSE_FORMAT = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "session_title",
+        "strict": True,
+        "schema": {
+            "type": "object",
+            "properties": {"title": {"type": "string"}},
+            "required": ["title"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+def _response(content):
+    return types.SimpleNamespace(
+        choices=[
+            types.SimpleNamespace(
+                message=types.SimpleNamespace(content=content),
+                finish_reason="stop",
+            )
+        ]
+    )
+
+
+@pytest.mark.parametrize("candidate", BAD_TITLE_OUTPUTS)
+def test_sanitizer_rejects_observed_reasoning_trace_titles(candidate):
+    assert streaming._sanitize_generated_title(candidate) == ""
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    (
+        "Fix session title generation",
+        "Reparar botón de inicio móvil",
+        "移动端登录按钮修复",
+    ),
+)
+def test_sanitizer_preserves_valid_titles_in_multiple_languages(candidate):
+    assert streaming._sanitize_generated_title(candidate) == candidate
+
+
+@pytest.mark.parametrize(
+    "content",
+    (
+        '{"title": "Fix login button on mobile"}',
+        '```json\n{"title": "Fix login button on mobile"}\n```',
+        'Here is the requested JSON:\n{"title": "Fix login button on mobile"}\nDone.',
+    ),
+)
+def test_extract_title_response_parses_json_wrappers(content):
+    assert streaming._extract_title_response(_response(content)) == (
+        "Fix login button on mobile",
+        "",
+    )
+
+
+def test_sanitizer_rejects_quoted_alternatives_and_bulleted_options():
+    assert streaming._sanitize_generated_title('"Fix title generation" or "Audit title generation"') == ""
+    assert streaming._sanitize_generated_title('- "Fix title generation"\n- "Audit title generation"') == ""
+
+
+def test_sanitizer_rejects_more_than_twelve_words_instead_of_truncating():
+    candidate = "Investigate why the mobile login button stops responding after users rotate their devices twice"
+    assert len(candidate.split()) > 12
+    assert streaming._sanitize_generated_title(candidate) == ""
+
+
+def test_overlong_title_response_uses_local_fallback(monkeypatch):
+    candidate = "Investigate why the mobile login button stops responding after users rotate their devices twice"
+    session = types.SimpleNamespace(
+        session_id="title-reasoning-fallback",
+        title="Untitled",
+        llm_title_generated=False,
+        manual_title=False,
+        messages=[
+            {"role": "user", "content": "Fix the mobile login button."},
+            {"role": "assistant", "content": "I will inspect the mobile event handling."},
+        ],
+        save=MagicMock(),
+    )
+    events = []
+
+    monkeypatch.setattr(streaming, "get_session", lambda _session_id: session)
+    monkeypatch.setattr(streaming, "SESSIONS", {session.session_id: session})
+    monkeypatch.setattr(streaming, "LOCK", threading.Lock())
+    monkeypatch.setattr(streaming, "_aux_title_generation_enabled", lambda: True)
+    monkeypatch.setattr(streaming, "_aux_title_configured", lambda: True)
+    monkeypatch.setattr(
+        streaming,
+        "generate_title_raw_via_aux",
+        lambda *_args, **_kwargs: (candidate, "llm_aux"),
+    )
+    monkeypatch.setattr(
+        "api.profiles.profile_env_for_background_worker",
+        lambda *_args, **_kwargs: nullcontext(),
+    )
+
+    streaming._run_background_title_update(
+        session_id=session.session_id,
+        user_text="Fix the mobile login button.",
+        assistant_text="I will inspect the mobile event handling.",
+        placeholder_title="Untitled",
+        put_event=lambda name, data: events.append((name, data)),
+        agent=None,
+    )
+
+    assert session.title == "Fix mobile login button"
+    assert session.save.call_args.kwargs == {"touch_updated_at": False}
+    status = [data for name, data in events if name == "title_status"]
+    assert status[-1]["status"] == "fallback"
+    assert status[-1]["reason"] == "local_summary:llm_invalid_aux"
+
+
+def test_aux_title_request_uses_strict_json_schema():
+    captured = {}
+
+    def fake_call_llm(**kwargs):
+        captured.update(kwargs)
+        return _response('{"title": "Fix login button on mobile"}')
+
+    with auxiliary_client_modules():
+        with patch_tg_config({"provider": "openai", "model": "gpt-4o-mini"}):
+            with patch("agent.auxiliary_client.call_llm", side_effect=fake_call_llm, create=True):
+                result, status = streaming.generate_title_raw_via_aux(
+                    "Why is login broken on mobile?",
+                    "The click handler is not attached.",
+                )
+
+    assert result == "Fix login button on mobile"
+    assert status == "llm_aux"
+    assert captured["extra_body"]["response_format"] == EXPECTED_RESPONSE_FORMAT
+
+
+def test_aux_schema_request_does_not_send_reasoning_extension():
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        extra = kwargs.get("extra_body") or {}
+        if "reasoning" in extra:
+            raise ValueError("strict gateway rejects reasoning")
+        return _response('{"title": "Schema Works"}')
+
+    with auxiliary_client_modules():
+        with patch_tg_config({"provider": "custom", "model": "strict-gateway"}):
+            with patch("agent.auxiliary_client.call_llm", side_effect=fake_call_llm, create=True):
+                result, status = streaming.generate_title_raw_via_aux(
+                    "Use a strict schema route.",
+                    "The route supports response_format.",
+                )
+
+    assert result == "Schema Works"
+    assert status == "llm_aux"
+    assert len(calls) == 1
+    assert "reasoning" not in calls[0]["extra_body"]
+
+
+def test_aux_schema_rejection_falls_back_to_existing_request_shape():
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        if "response_format" in (kwargs.get("extra_body") or {}):
+            raise ValueError("response_format unsupported")
+        return _response("Compatibility Fallback Title")
+
+    with auxiliary_client_modules():
+        with patch_tg_config({"provider": "custom", "model": "legacy-gateway"}):
+            with patch("agent.auxiliary_client.call_llm", side_effect=fake_call_llm, create=True):
+                result, status = streaming.generate_title_raw_via_aux(
+                    "Use a legacy title route.",
+                    "The route rejects response_format.",
+                )
+
+    assert result == "Compatibility Fallback Title"
+    assert status == "llm_aux_retry"
+    assert len(calls) == 2
+    assert calls[1]["extra_body"] == {"reasoning": {"enabled": False}}
+
+
+def test_extract_title_response_rejects_json_without_string_title():
+    assert streaming._extract_title_response(_response('{"options": ["one", "two"]}')) == (
+        "",
+        "llm_empty",
+    )
+
+
+def test_agent_openai_title_request_uses_strict_json_schema():
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _response('{"title": "Fix login button on mobile"}')
+
+    client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=fake_create))
+    )
+    agent = MagicMock()
+    agent.api_mode = "openai"
+    agent.provider = "openai"
+    agent.model = "gpt-4o-mini"
+    agent.base_url = "https://api.openai.com/v1"
+    agent.reasoning_config = None
+    agent._build_api_kwargs.return_value = {}
+    agent._ensure_primary_openai_client.return_value = client
+
+    result, status = streaming.generate_title_raw_via_agent(
+        agent,
+        "Why is login broken on mobile?",
+        "The click handler is not attached.",
+    )
+
+    assert result == "Fix login button on mobile"
+    assert status == "llm"
+    assert captured["extra_body"]["response_format"] == EXPECTED_RESPONSE_FORMAT
+    assert agent.reasoning_config is None

--- a/tests/test_title_reasoning_trace_guard.py
+++ b/tests/test_title_reasoning_trace_guard.py
@@ -200,6 +200,36 @@ def test_aux_schema_rejection_falls_back_to_existing_request_shape():
     assert calls[1]["extra_body"] == {"reasoning": {"enabled": False}}
 
 
+def test_aux_schema_reasoning_only_retries_with_reasoning_disabled_shape():
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        if "response_format" in (kwargs.get("extra_body") or {}):
+            return {
+                "choices": [
+                    {
+                        "message": {"content": "", "reasoning": "hidden reasoning"},
+                        "finish_reason": "length",
+                    }
+                ]
+            }
+        return _response("Compatibility Reasoning Fallback")
+
+    with auxiliary_client_modules():
+        with patch_tg_config({"provider": "custom", "model": "reasoning-gateway"}):
+            with patch("agent.auxiliary_client.call_llm", side_effect=fake_call_llm, create=True):
+                result, status = streaming.generate_title_raw_via_aux(
+                    "Use a reasoning title route.",
+                    "The schema request returns reasoning only.",
+                )
+
+    assert result == "Compatibility Reasoning Fallback"
+    assert status == "llm_aux_retry"
+    assert len(calls) == 2
+    assert calls[1]["extra_body"] == {"reasoning": {"enabled": False}}
+
+
 def test_extract_title_response_rejects_json_without_string_title():
     assert streaming._extract_title_response(_response('{"options": ["one", "two"]}')) == (
         "",
@@ -235,4 +265,38 @@ def test_agent_openai_title_request_uses_strict_json_schema():
     assert result == "Fix login button on mobile"
     assert status == "llm"
     assert captured["extra_body"]["response_format"] == EXPECTED_RESPONSE_FORMAT
+    assert agent.reasoning_config is None
+
+
+def test_agent_schema_rejection_falls_back_to_existing_request_shape():
+    calls = []
+
+    def fake_create(**kwargs):
+        calls.append(kwargs)
+        if "response_format" in (kwargs.get("extra_body") or {}):
+            raise ValueError("response_format unsupported")
+        return _response("Compatibility Agent Title")
+
+    client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=fake_create))
+    )
+    agent = MagicMock()
+    agent.api_mode = "openai"
+    agent.provider = "minimax"
+    agent.model = "minimax-m2"
+    agent.base_url = "https://api.minimaxi.com/v1"
+    agent.reasoning_config = None
+    agent._build_api_kwargs.return_value = {}
+    agent._ensure_primary_openai_client.return_value = client
+
+    result, status = streaming.generate_title_raw_via_agent(
+        agent,
+        "Why is the title route failing?",
+        "The endpoint rejects response_format.",
+    )
+
+    assert result == "Compatibility Agent Title"
+    assert status == "llm_retry"
+    assert len(calls) == 2
+    assert calls[1]["extra_body"] == {"reasoning_split": True}
     assert agent.reasoning_config is None


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI generates sidebar session titles with its own LLM call and persists them to `webui/sessions/*.json`.
- Real sessions on this install stored the title model's meta-reasoning as the literal title instead of a topic label.
- The aux/agent title path used a free-text prompt with no `response_format`, and `_looks_invalid_generated_title()` missed the observed ramble shapes.
- The core agent titler already solves this with a strict `{"title": "..."}` schema, JSON unwrap, and a >12-word reject-instead-of-truncate guard.
- This PR ports that approach into WebUI and hardens the sanitizer so leaked reasoning cannot persist.

## Contract Routing

Task type: runtime / session-metadata bugfix
Touched areas: `api/streaming.py` title generation, sanitizer, aux/agent request extra_body
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/webui-run-state-consistency-contract.md` (sidebar/session metadata layer)
Scope boundaries: no UI/CSS, no CHANGELOG, no prompt rewrite beyond request shape + sanitizer
Evidence needed before claiming done: failing tests on current master, passing title suite after the fix

## What Changed

- Aux title generation now tries a schema-only `response_format` request first (`{"title": string}`, strict), then falls back to the existing reasoning-disable extra_body if the route rejects or ignores schema.
- OpenAI-compatible agent title generation sends the same schema first, then retries the same prompt and token budget with the route's original compatibility shape when the schema is rejected or returns empty/reasoning-only output.
- `_extract_title_response()` unwraps direct JSON, markdown-fenced JSON, and loosely embedded `{"title": "..."}` before falling back to prose.
- `_looks_invalid_generated_title()` now rejects the observed leakage prefixes (`Title should`, `Something like`, `Good title`, `Options:`, `maybe `), `3-8 words` / `topic label`, and quoted-alternative lists.
- `_sanitize_generated_title()` rejects titles over 12 words instead of truncating them, so callers fall through to the next prompt / local fallback.

## Why It Matters

Without this, reasoning models (including glm-5.3-flash via `auto` when no dedicated title model is configured) store prompt-echo and candidate-list ramble as the sidebar title. That is the session metadata layer, not live stream state.

Observed persisted titles:

- `Title should be 3-8 words, matching the user's language (English), topic label s…`
- `Something like "Fix Session Title Generation" or "Audit Session Title Generation…`
- `Good title: "Budget 2-Stage Snow Blower Recommendations" or "Cheapest Well-Revie…`
- `Options: - "Durable Bathroom Flooring Options" - "Cost-Effective Bathroom Floor…`

Related: #7413 / #7417 (schema-first aux path). This PR also covers the sanitizer gap and the agent OpenAI path, and it was written against current `master`.

## Verification

RED (new tests vs current `master` sanitizer/extractor):

```
12 failed, 3 passed
```

GREEN after the fix:

```
python -m pytest tests/test_title_reasoning_trace_guard.py -q
18 passed in 5.82s

python -m pytest tests/ -k title -x -q
368 passed, 14 skipped, 14958 deselected, 8 subtests passed in 38.90s

python -m pytest tests/test_title_reasoning_trace_guard.py tests/test_title_sanitization.py tests/test_title_aux_routing.py tests/test_title_gen_reasoning_extra_gate.py tests/test_2235_initial_aux_title.py tests/test_1058_adaptive_title_refresh.py tests/test_3230_preserve_manual_session_title.py tests/test_early_session_title.py -q
156 passed, 8 subtests passed in 26.37s
```

The Windows host full-suite shards fail on POSIX path/ACL/ctl.sh/docker fixtures unrelated to titles. I did not treat those as regressions from this change.

Could not verify: a live title-generation call against glm-5.3-flash in this install (no production title model was invoked).

Follow-up review verification:

```
python -m pytest tests/*title*.py -q
240 passed, 7 skipped, 8 subtests passed

python -m pytest tests/*streaming*.py tests/test_agent_v021_transport_normalize.py -q
202 passed

python scripts/ruff_lint.py --diff origin/master
0 new violations
```

## Risks / Follow-ups

- Aux schema extra_body is schema-only (no `reasoning` field) so strict OpenAI-compatible gateways succeed on the first call. Compatibility fallback still uses the existing reasoning-disable shape.
- Agent and auxiliary OpenAI-compatible paths preserve route-specific compatibility fields when the strict schema is unavailable or yields no title; compatibility-mode reasoning-only output still short-circuits to avoid repeated model spend.
- Existing valid titles, JSON-wrapped responses, `llm_empty_reasoning` short-circuit, and the manual-title guard remain covered by neighboring tests.

## Model Used

xAI grok-4.6 via Hermes Agent (WebUI) for the original change; OpenAI Codex gpt-5.6-sol via Hermes Agent for review follow-ups. Tools used: git, pytest, `gh`.