### PR TITLE
fix(chat): build attachment references on the server

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -358,6 +358,36 @@ POST /api/approval/respond:
 
 ### 4.6 File Upload Parser
 
+#### Chat attachment handoff
+
+For a fresh `POST /api/chat/start`, clients send their message text and the
+structured `attachments` array returned by uploading. Each ordinary file has
+`name` (or `filename`), `path`, `mime`, `size` and `is_image`. The path is the
+server-side location, not a client filesystem path. Extracted archives may
+supply a directory path. The existing limit of 20 attachments applies.
+
+`api.upload.build_chat_attachment_message` resolves references against the
+selected workspace or configured attachment inbox, rejects unavailable or
+out-of-scope references, and constructs the model-facing text before the turn
+is checkpointed, journalled or dispatched. It does not read file bytes.
+
+- Text plus attachments becomes `text` followed by `[Attached files: ...]`.
+- Attachments without text become `Uploaded: <filenames>` followed by the same
+  `[Attached files: ...]` suffix, keeping paths out of the ordinary display.
+- Text without attachments retains its existing behaviour.
+- Neither text nor usable attachments returns a client error. A request with
+  an invalid attachment is rejected as a whole, not run with a partial list.
+
+The browser no longer builds these strings. It still uploads files, submits
+attachment objects and renders attachment cards. Native image embedding keeps
+using the structured metadata; text-mode agents receive paths for file/vision
+tools. Regeneration reuses the already formatted retained turn, as do recovery
+and replay. No legacy-client suffix detection or history migration is performed.
+This contract applies to chat-start, not the separate steer or synchronous-chat
+endpoints. Existing tool access checks still apply when a file is consumed.
+
+#### Multipart parsing
+
 parse_multipart(rfile, content_type, content_length):
     - Reads all content_length bytes from rfile into memory (up to MAX_UPLOAD_BYTES, default 20MB, env-overridable via HERMES_WEBUI_MAX_UPLOAD_MB)
     - Extracts boundary from Content-Type header

--- a/api/models.py
+++ b/api/models.py
@@ -6530,7 +6530,7 @@ def all_sessions(
 
 
 def _strip_attached_files_marker(text: str) -> str:
-    return re.sub(r"\n\n\[Attached files: [^\]]+\]$", "", str(text or "")).strip()
+    return re.sub(r"\n\n\[Attached files: [^\r\n]+\]$", "", str(text or "")).strip()
 
 
 def title_from(messages, fallback: str='Untitled'):

--- a/api/routes.py
+++ b/api/routes.py
@@ -24159,7 +24159,7 @@ def _handle_chat_start(handler, body, diag=None):
             attachments = None
         diag.stage("normalize_message") if diag else None
         msg = str(msg if msg is not None else body.get("message", "")).strip()
-        if not msg:
+        if not msg and not (body.get("attachments") or attachments):
             return bad(handler, "message is required")
         diag.stage("normalize_attachments") if diag else None
         if attachments is None:
@@ -24187,6 +24187,15 @@ def _handle_chat_start(handler, body, diag=None):
             return bad(handler, str(e), 500)
         except ValueError as e:
             return bad(handler, str(e))
+        if regeneration is None:
+            from api.upload import build_chat_attachment_message
+
+            try:
+                msg = build_chat_attachment_message(msg, attachments, workspace)
+            except ValueError as exc:
+                return bad(handler, str(exc))
+            if not msg:
+                return bad(handler, "message is required")
         requested_model = body.get("model") or s.model
         requested_provider = (
             body.get("model_provider")
@@ -24378,7 +24387,8 @@ def _normalize_chat_attachments(raw_attachments):
     for item in raw_attachments:
         if isinstance(item, dict):
             name = str(item.get("name") or item.get("filename") or "").strip()
-            path = str(item.get("path") or "").strip()
+            raw_path = item.get("path")
+            path = raw_path.strip() if isinstance(raw_path, str) else ""
             mime = str(item.get("mime") or "").strip()
             att = {"name": name or path, "path": path, "mime": mime}
             size = item.get("size")

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3926,7 +3926,7 @@ def _strip_workspace_prefix(text: str, *, include_legacy: bool = False) -> str:
 
 
 _TITLE_ATTACHMENT_SUFFIX_RE = re.compile(
-    r'(?:\n\n|\r\n\r\n)\[Attached files(?: for this steer)?: [^\]]+\]\s*$'
+    r'(?:\n\n|\r\n\r\n)\[Attached files(?: for this steer)?: [^\r\n]+\]\s*$'
 )
 
 

--- a/api/upload.py
+++ b/api/upload.py
@@ -122,6 +122,43 @@ def _attachment_root() -> Path:
     return (STATE_DIR / 'attachments').resolve()
 
 
+def build_chat_attachment_message(message: str, attachments: list, workspace: str) -> str:
+    """Format fresh chat input before checkpointing or dispatching it.
+
+    Clients supply upload metadata, not model-facing text. Retained turns already
+    contain this text and must not pass through fresh-input formatting again.
+    Use the same permitted roots as native image embedding; file bytes remain
+    the responsibility of the consuming tool or native image builder.
+    """
+    if not attachments:
+        return message
+    roots = (Path(workspace).expanduser().resolve(), _attachment_root())
+    references = []
+    for index, attachment in enumerate(attachments, start=1):
+        raw_path = attachment.get('path') if isinstance(attachment, dict) else None
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            raise ValueError(f'Attachment {index} requires a usable path')
+        try:
+            path = Path(raw_path).expanduser()
+            if not path.is_absolute():
+                path = roots[0] / path
+            path = path.resolve(strict=True)
+            if not any(path.is_relative_to(root) for root in roots):
+                raise ValueError('outside permitted attachment locations')
+            if not (path.is_file() or path.is_dir()):
+                raise ValueError('not a file or directory')
+        except (OSError, ValueError, RuntimeError) as exc:
+            raise ValueError(f'Attachment {index} is unavailable or outside permitted locations') from exc
+        # Keep embedding and model-facing text on the same resolved path.
+        attachment['path'] = str(path)
+        references.append(str(path))
+    joined = ', '.join(references)
+    if not message:
+        names = ', '.join(Path(reference).name for reference in references)
+        message = f'Uploaded: {names}'
+    return f'{message}\n\n[Attached files: {joined}]'
+
+
 def _upload_destination(session_id: str, safe_name: str, dest_dir: Path | None = None) -> Path:
     dest_dir = dest_dir if dest_dir is not None else _session_attachment_dir(session_id)
     dest_dir.mkdir(parents=True, exist_ok=True)

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -23,6 +23,12 @@ contributor guidance; it does not change runtime behavior or CI gates.
 
 ## Runtime, durability, and state contracts
 
+- [`ARCHITECTURE.md`, Chat attachment handoff](../ARCHITECTURE.md#chat-attachment-handoff):
+  fresh `/api/chat/start` requests use structured `attachments`; the server
+  constructs reference text before persistence and dispatch. Attachment-only
+  requests are accepted, invalid references reject the whole request, and
+  regeneration reuses the stored turn without formatting it again.
+
 - [`docs/rfcs/webui-run-state-consistency-contract.md`](rfcs/webui-run-state-consistency-contract.md):
   proposed consistency rules for current WebUI streaming, recovery, replay,
   model-context reconstruction, compression, UI scene/cache, and sidebar metadata

--- a/static/messages.js
+++ b/static/messages.js
@@ -1656,10 +1656,8 @@ async function send(){
   setComposerStatus('');
 
   const uploadedNames=uploaded.map(u=>u.name||u);
-  const uploadedPaths=uploaded.map(u=>u&&u.path?u.path:(u&&u.name?u.name:(u&&u.filename?u.filename:u)));
+  // The server constructs attachment context before persisting the turn.
   let msgText=text;
-  if(uploaded.length&&!msgText)msgText=`I've uploaded ${uploaded.length} file(s): ${uploadedPaths.join(', ')}`;
-  else if(uploaded.length)msgText=`${text}\n\n[Attached files: ${uploadedPaths.join(', ')}]`;
   if(_forcedSkillDirectivePending){
     const _pending=_forcedSkillDirectivePending;
     if(!_pending.sessionId||_pending.sessionId===activeSid){
@@ -1682,7 +1680,7 @@ async function send(){
       }
     }
   }
-  if(!msgText){setComposerStatus('Nothing to send');return;}
+  if(!msgText&&!uploaded.length){setComposerStatus('Nothing to send');return;}
   // Composer textarea + persisted draft were already captured and cleared
   // immediately after capture (above, salvage of #4750 + #5912 gate fix) to close
   // the re-entrant double-send race AND avoid clobbering a draft typed during the

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3282,7 +3282,7 @@ function _messageComparableText(m){
 }
 
 function _stripAttachedFilesMarker(text){
-  return String(text||'').replace(/\n\n\[Attached files: [^\]]+\]$/,'').trim();
+  return String(text||'').replace(/\n\n\[Attached files: [^\r\n]+\]$/,'').trim();
 }
 
 function _stripForcedSkillEnvelope(text){
@@ -7284,7 +7284,7 @@ function _sessionDisplayTitle(s){
   const rawTitle=String((s&&(s.display_title||s._state_db_title||s.title))||'Untitled').trim();
   const strip=(typeof _stripAttachedFilesMarker==='function')
     ? _stripAttachedFilesMarker
-    : (text)=>String(text||'').replace(/\n\n\[Attached files: [^\]]+\]$/,'').trim();
+    : (text)=>String(text||'').replace(/\n\n\[Attached files: [^\r\n]+\]$/,'').trim();
   const title=strip(rawTitle);
   return title||'Untitled';
 }

--- a/static/ui.js
+++ b/static/ui.js
@@ -8222,7 +8222,7 @@ function renderMd(raw){
 }
 
 function _stripAttachedFilesMarkerForDisplay(text){
-  return String(text||'').replace(/\n\n\[Attached files: [^\]]+\]$/,'').trim();
+  return String(text||'').replace(/\n\n\[Attached files: [^\r\n]+\]$/,'').trim();
 }
 
 function setStatus(t){

--- a/tests/test_chat_upload_attachment_paths.py
+++ b/tests/test_chat_upload_attachment_paths.py
@@ -7,19 +7,105 @@ MESSAGES_JS = ROOT / "static" / "messages.js"
 UPLOAD_PY = ROOT / "api" / "upload.py"
 
 
-def test_image_uploads_use_server_path_in_attached_files_context():
-    """The agent text context must include real uploaded paths for images.
+def test_browser_submits_raw_text_and_structured_uploads():
+    """Execute formatting, admission and the production request expression in Node."""
+    import json
+    import subprocess
 
-    /api/upload returns an absolute attachment path. The browser also sends the
-    structured attachment payload to /api/chat/start, but text/tool-mode agents
-    still rely on the literal ``[Attached files: ...]`` suffix. Images must not
-    be downgraded to bare filenames there, otherwise tools like vision_analyze
-    cannot open the uploaded file immediately.
-    """
     src = MESSAGES_JS.read_text(encoding="utf-8")
+    formatting = src[src.index('  const uploadedNames='):src.index('  // Composer textarea + persisted draft were already')]
+    start = src.index("JSON.stringify({", src.index("const startData=await api('/api/chat/start'"))
+    end = src.index('})});', start) + 2
+    request = src[start:end]
+    script = '''
+const uploaded=[{name:'photo.jpg',path:'/uploads/photo.jpg',mime:'image/jpeg',size:12,is_image:true}];
+const activeSid='session';
+const S={session:{workspace:'/workspace'},activeProfile:'default'};
+const _modelState={model:'model',model_provider:'provider'};
+const _explicitPick=false, _pendingMoaConfig=null, _forcedSkillDirectivePending=null;
+const statuses=[];
+function setComposerStatus(text){statuses.push(text);}
+async function build(text){
+''' + formatting + '\nreturn ' + request + ';\n}\n' + '''
+(async()=>{
+const requests=await Promise.all(['Describe this',''].map(async text=>{
+  const body=await build(text); return body ? JSON.parse(body) : null;
+}));
+uploaded.length=0;
+const empty=await build('');
+process.stdout.write(JSON.stringify({requests,statuses,emptyRejected:empty===undefined}));
+})();
+'''
+    result = subprocess.run(['node', '-e', script], cwd=ROOT, text=True,
+                            capture_output=True, check=True)
+    output = json.loads(result.stdout)
+    requests = output['requests']
+    assert all(body is not None for body in requests), output
+    assert output['statuses'] == ['Nothing to send']
+    assert output['emptyRejected'] is True
+    assert [body['message'] for body in requests] == ['Describe this', '']
+    for body in requests:
+        assert body['attachments'] == [dict(name='photo.jpg', path='/uploads/photo.jpg',
+                                           mime='image/jpeg', size=12, is_image=True)]
 
-    assert "uploadedPaths=uploaded.map(u=>u&&u.is_image?" not in src
-    assert "uploadedPaths=uploaded.map(u=>u&&u.path?u.path" in src
+
+def test_attachment_only_text_matches_optimistic_display_and_title(tmp_path, monkeypatch):
+    """The stored turn must reconcile with the filename-only optimistic row."""
+    import json
+    import subprocess
+    from api.models import title_from
+    from api.upload import build_chat_attachment_message
+
+    monkeypatch.setenv('HERMES_WEBUI_ATTACHMENT_DIR', str(tmp_path))
+    path = tmp_path / 'photo.jpg'
+    path.write_bytes(b'image fixture')
+    canonical = build_chat_attachment_message('', [{'name': path.name, 'path': str(path)}], str(tmp_path))
+    functions = []
+    for filename, name in [('ui.js', '_stripAttachedFilesMarkerForDisplay'),
+                           ('sessions.js', '_stripAttachedFilesMarker'),
+                           ('sessions.js', '_stripForcedSkillEnvelope'),
+                           ('sessions.js', '_normalizeUserTranscriptText')]:
+        src = (ROOT / 'static' / filename).read_text(encoding='utf-8')
+        start = src.index(f'function {name}(')
+        end = src.index('\n}', start) + 2
+        functions.append(src[start:end])
+    script = '\n'.join(functions) + '\nconst canonical=' + json.dumps(canonical) + ';\n' + '''
+process.stdout.write(JSON.stringify({
+ display:_stripAttachedFilesMarkerForDisplay(canonical),
+ reconciles:_normalizeUserTranscriptText(canonical)===_normalizeUserTranscriptText('Uploaded: photo.jpg')
+}));
+'''
+    result = subprocess.run(['node', '-e', script], cwd=ROOT, text=True,
+                            capture_output=True, check=True)
+    observed = json.loads(result.stdout)
+    assert observed == {'display': 'Uploaded: photo.jpg', 'reconciles': True}
+    assert title_from([{'role': 'user', 'content': canonical}]) == 'Uploaded: photo.jpg'
+
+
+def test_marker_punctuation_in_path_stays_hidden_from_display():
+    """A valid filename must not leak the model-only suffix into the transcript."""
+    import json
+    import subprocess
+
+    from api.models import title_from
+    from api.streaming import _strip_title_attachment_suffix
+
+    text = 'Describe this\n\n[Attached files: /uploads/photo [1].jpg]'
+    assert title_from([{'role': 'user', 'content': text}]) == 'Describe this'
+    assert _strip_title_attachment_suffix(text) == 'Describe this'
+    for filename, function in [('ui.js', '_stripAttachedFilesMarkerForDisplay'),
+                               ('sessions.js', '_stripAttachedFilesMarker')]:
+        src = (ROOT / 'static' / filename).read_text(encoding='utf-8')
+        start = src.index(f'function {function}(')
+        end = src.index('\n}', start) + 2
+        script = src[start:end] + f'''
+const paths=['/uploads/résumé 1.jpg','/uploads/photo [1].jpg'];
+process.stdout.write(JSON.stringify(paths.map(path =>
+  {function}('Describe this\\n\\n[Attached files: '+path+']'))));
+'''
+        result = subprocess.run(['node', '-e', script], cwd=ROOT, text=True,
+                                capture_output=True, check=True)
+        assert json.loads(result.stdout) == ['Describe this', 'Describe this']
 
 
 def test_attached_files_context_is_hidden_from_user_message_display():
@@ -38,7 +124,6 @@ def test_attached_files_context_is_hidden_from_sidebar_titles():
 
     assert "function _stripAttachedFilesMarker" in sessions_src
     assert "? _stripAttachedFilesMarker" in sessions_src
-    assert "replace(/\\n\\n\\[Attached files: [^\\]]+\\]$/" in sessions_src
 
 
 def test_server_provisional_titles_strip_attached_files_context():

--- a/tests/test_issue2977_use_command.py
+++ b/tests/test_issue2977_use_command.py
@@ -70,8 +70,8 @@ def test_directive_consumed_at_injection_site():
 def test_directive_injection_before_empty_guard():
     src = read("static/messages.js")
     inject_pos = src.index("_forcedSkillDirectivePending")
-    guard_pos = src.index("if(!msgText){setComposerStatus('Nothing to send');return;}")
-    assert inject_pos < guard_pos, "directive injection must appear before the if(!msgText) guard"
+    guard_pos = src.index("if(!msgText&&!uploaded.length){setComposerStatus('Nothing to send');return;}")
+    assert inject_pos < guard_pos, "directive injection must appear before the empty-message-and-attachments guard"
 
 
 def test_directive_text_uses_match_name():

--- a/tests/test_server_side_attachment_references.py
+++ b/tests/test_server_side_attachment_references.py
@@ -1,0 +1,287 @@
+"""Client-neutral chat attachment handoff, through real request preparation."""
+import copy
+from types import SimpleNamespace
+
+import pytest
+
+from api import routes
+from api.models import Session
+from api.streaming import _build_native_multimodal_message
+
+
+@pytest.fixture
+def intake(monkeypatch, tmp_path):
+    real_start = routes._start_run
+    workspace = tmp_path / 'workspace'
+    workspace.mkdir()
+    inbox = tmp_path / 'inbox'
+    inbox.mkdir()
+    monkeypatch.setenv('HERMES_WEBUI_ATTACHMENT_DIR', str(inbox))
+    session = Session(session_id='attachment-test', workspace=str(workspace),
+                      model='test-model', model_provider='test-provider', profile='default')
+    calls = []
+    monkeypatch.setattr(routes, '_agent_runtime_barrier_response', lambda **kw: None)
+    monkeypatch.setattr(routes, '_get_or_materialize_session', lambda *a, **kw: session)
+    monkeypatch.setattr(routes, '_resolve_chat_workspace_with_recovery', lambda *a: str(workspace))
+    monkeypatch.setattr(routes, '_resolve_chat_workspace_for_regeneration', lambda *a: str(workspace))
+    monkeypatch.setattr(routes, '_read_profile_model_config', lambda *a: (None, None, {}))
+    monkeypatch.setattr(routes, '_resolve_compatible_session_model_state',
+                        lambda *a, **kw: ('test-model', 'test-provider', False))
+    monkeypatch.setattr(routes, '_repair_foreign_session_model_provider',
+                        lambda *a, **kw: 'test-provider')
+    monkeypatch.setattr(routes, 'get_config_snapshot', lambda: {})
+    monkeypatch.setattr(routes, 'webui_gateway_chat_enabled', lambda cfg: False)
+    monkeypatch.setattr(routes, 'j', lambda h, payload, status=200: (status, payload))
+    monkeypatch.setattr(routes, 'bad', lambda h, error, status=400: (status, {'error': error}))
+
+    def start(s, **kw):
+        calls.append(copy.deepcopy(kw))
+        return {'stream_id': 'test-stream'}
+
+    monkeypatch.setattr(routes, '_start_run', start)
+
+    def submit(text='Describe this', attachments=None, **kw):
+        return routes._handle_chat_start(None, dict(
+            session_id=session.session_id, message=text,
+            attachments=attachments or [], **kw))
+
+    def file(name='photo.jpg', where=None):
+        target = (where or workspace) / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b'\xff\xd8\xffexample-image')
+        return {'name': name, 'path': str(target), 'mime': 'image/jpeg',
+                'size': target.stat().st_size, 'is_image': True}
+
+    return SimpleNamespace(submit=submit, file=file, calls=calls, session=session,
+                           workspace=workspace, inbox=inbox, real_start=real_start)
+
+
+@pytest.mark.parametrize('gateway', [False, True])
+@pytest.mark.parametrize('save_mode', ['eager', 'deferred'])
+def test_request_journal_and_worker_receive_the_same_turn(intake, monkeypatch, tmp_path, gateway, save_mode):
+    from api import models, turn_journal, gateway_chat
+    import threading
+
+    monkeypatch.setattr(routes, '_start_run', intake.real_start)
+    monkeypatch.setattr('api.runtime_adapter.runtime_adapter_enabled', lambda: False)
+    monkeypatch.setattr('api.runtime_adapter.runtime_adapter_runner_enabled', lambda: False)
+    monkeypatch.setattr(routes, 'webui_gateway_chat_enabled', lambda cfg: gateway)
+    monkeypatch.setattr(routes, 'get_webui_session_save_mode', lambda: save_mode)
+    monkeypatch.setattr(routes, '_active_run_stream_for_session', lambda sid: None)
+    monkeypatch.setattr(routes, 'set_last_workspace', lambda path: None)
+    monkeypatch.setattr(routes, 'publish_session_list_changed', lambda *a, **kw: None)
+    monkeypatch.setattr(gateway_chat, '_mark_gateway_run_starting', lambda sid: None)
+    monkeypatch.setattr(turn_journal, '_default_session_dir', lambda: tmp_path / 'journal')
+    monkeypatch.setattr(models, 'SESSION_DIR', tmp_path / 'sessions')
+    (tmp_path / 'sessions').mkdir()
+    workers = []
+
+    class Worker:
+        def __init__(self, *, target, args, kwargs, daemon):
+            self.target, self.args = target, args
+
+        def start(self):
+            events = turn_journal.read_turn_journal(intake.session.session_id)['events']
+            # The submitted row must be durable before the worker is started.
+            workers.append((self.target, self.args, events[-1]))
+
+    monkeypatch.setattr(routes, 'threading', SimpleNamespace(
+        Thread=Worker, Lock=threading.Lock, RLock=threading.RLock))
+    att = intake.file()
+    status, body = intake.submit('Read', [att])
+    assert status == 200, body
+    assert len(workers) == 1
+    target, args, event = workers[0]
+    expected = f'Read\n\n[Attached files: {att["path"]}]'
+    assert target is (routes._run_gateway_chat_streaming if gateway else routes._run_agent_streaming)
+    assert args[1] == event['content'] == intake.session.pending_user_message == expected
+    assert args[5] == event['attachments'] == intake.session.pending_attachments
+    assert event['event'] == 'submitted'
+    # Worker launch is intercepted, not the production intake/persistence path.
+    import json
+    saved = json.loads((tmp_path / 'sessions' / f'{intake.session.session_id}.json').read_text())
+    assert saved['pending_user_message'] == expected
+    assert saved['pending_attachments'] == args[5]
+    stream_id = body['stream_id']
+    routes.STREAMS.pop(stream_id, None)
+    routes.unregister_stream_owner(stream_id)
+
+
+@pytest.mark.parametrize('save_mode', ['eager', 'deferred'])
+def test_canonical_turn_survives_checkpoint_recovery_and_regeneration(intake, monkeypatch, tmp_path, save_mode):
+    import json
+    from api.models import _append_recovered_pending_turn
+    from api.session_ops import plan_regeneration
+    from api.streaming import _context_messages_for_new_turn
+    from api.turn_journal import append_turn_journal_event, read_turn_journal
+
+    att = intake.file()
+    assert intake.submit('Read this', [att])[0] == 200
+    turn = intake.calls[-1]
+    expected = f'Read this\n\n[Attached files: {att["path"]}]'
+    assert turn['msg'] == expected
+    monkeypatch.setattr(routes, 'get_webui_session_save_mode', lambda: save_mode)
+    routes._prepare_chat_start_session_for_stream(
+        intake.session, msg=turn['msg'], attachments=turn['attachments'],
+        workspace=turn['workspace'], model=turn['model'], model_provider=turn['model_provider'],
+        stream_id='checkpoint-stream', started_at=123, defer_save=True)
+    assert intake.session.pending_user_message == expected
+    if save_mode == 'eager':
+        assert intake.session.messages[0]['content'] == expected
+    event = append_turn_journal_event(intake.session.session_id, {
+        'event': 'submitted', 'stream_id': 'checkpoint-stream',
+        'content': intake.session.pending_user_message,
+        'attachments': intake.session.pending_attachments,
+    }, session_dir=tmp_path)
+    events = read_turn_journal(intake.session.session_id, session_dir=tmp_path)['events']
+    assert events[-1]['content'] == expected
+    assert events[-1]['turn_id'] == event['turn_id']
+    # JSON boundary, followed by the real pending-turn recovery and context builder.
+    restored = Session(session_id='restored', workspace=str(intake.workspace),
+                       pending_user_message=json.loads(json.dumps(expected)),
+                       pending_attachments=json.loads(json.dumps(turn['attachments'])))
+    _append_recovered_pending_turn(restored, timestamp=123)
+    _append_recovered_pending_turn(restored, timestamp=123)
+    context = _context_messages_for_new_turn(restored, 'Follow up')
+    assert len([m for m in context if m.get('content') == expected]) == 1
+    # Regeneration is only admitted after the recovered turn has settled.
+    restored.pending_user_message = None
+    restored.pending_attachments = []
+    restored.messages.append({'role': 'assistant', 'content': 'Done'})
+    restored.context_messages = copy.deepcopy(restored.messages)
+    plan = plan_regeneration(restored)
+    assert plan.turn.message_text == expected
+    assert plan.turn.message_text.count('[Attached files:') == 1
+
+
+def test_regeneration_does_not_reformat_retained_turn(intake, monkeypatch):
+    att = intake.file()
+    expected = f'Read\n\n[Attached files: {att["path"]}]'
+    retained = SimpleNamespace(turn=SimpleNamespace(message_text=expected, attachments=[att]))
+    monkeypatch.setattr('api.session_ops.plan_regeneration', lambda *a, **kw: retained)
+    monkeypatch.setattr('api.runtime_adapter.runtime_adapter_runner_enabled', lambda: False)
+    status, _ = routes._handle_chat_start(None, {
+        'session_id': intake.session.session_id, 'regenerate': True,
+        'regeneration_revision': 'revision'})
+    assert status == 200
+    assert intake.calls[-1]['msg'] == expected
+
+
+@pytest.mark.parametrize('gateway', [False, True])
+@pytest.mark.parametrize('text', ['Describe this', ''])
+def test_structured_attachment_reaches_model_without_client_suffix(intake, monkeypatch, gateway, text):
+    monkeypatch.setattr(routes, 'webui_gateway_chat_enabled', lambda cfg: gateway)
+    att = intake.file(where=intake.inbox / intake.session.session_id)
+    status, body = intake.submit(text, [att])
+    assert status == 200, body
+    turn = intake.calls[-1]
+    expected = (f'{text}\n\n[Attached files: {att["path"]}]' if text else
+                f"Uploaded: photo.jpg\n\n[Attached files: {att['path']}]")
+    assert turn['msg'] == expected
+    assert turn['attachments'][0]['path'] == att['path']
+    assert turn['gateway_chat_enabled'] is gateway
+    content = _build_native_multimodal_message('', turn['msg'], turn['attachments'],
+                                              str(intake.workspace),
+                                              cfg={'agent': {'image_input_mode': 'text'}})
+    assert content == expected
+
+
+def test_text_only_and_empty_admission(intake):
+    assert intake.submit('plain')[0] == 200
+    assert intake.calls[-1]['msg'] == 'plain'
+    intake.calls.clear()
+    assert intake.submit('')[0] == 400
+    assert not intake.calls
+
+
+def test_multiple_files_and_extracted_directory_keep_order(intake):
+    first = intake.file('résumé 1.txt')
+    directory = intake.workspace / 'archive'
+    directory.mkdir()
+    second = {'name': 'archive', 'path': str(directory), 'extracted': 2}
+    assert intake.submit('Read these', [first, second, first])[0] == 200
+    assert intake.calls[-1]['msg'] == (
+        f'Read these\n\n[Attached files: {first["path"]}, {directory}, {first["path"]}]')
+
+
+@pytest.mark.parametrize('invalid', ['missing', 'outside', 'symlink', 'empty', 'malformed'])
+def test_invalid_attachment_rejects_entire_turn(intake, tmp_path, invalid):
+    valid = intake.file()
+    if invalid == 'missing':
+        bad = {'path': str(intake.workspace / 'missing.jpg')}
+    elif invalid == 'outside':
+        bad = intake.file('private.jpg', where=tmp_path)
+    elif invalid == 'symlink':
+        outside = intake.file('private.jpg', where=tmp_path)
+        link = intake.workspace / 'escape.jpg'
+        link.symlink_to(outside['path'])
+        bad = {'path': str(link)}
+    elif invalid == 'empty':
+        bad = {'name': 'missing.jpg', 'path': ''}
+    else:
+        bad = {'path': {'not': 'a path'}}
+    status, _ = intake.submit('Read both', [valid, bad])
+    assert status == 400
+    assert not intake.calls
+    assert not intake.session.pending_user_message
+
+
+@pytest.mark.parametrize('value', [123, ['photo.jpg'], {'name': 'photo.jpg'}, True])
+def test_non_string_path_is_rejected_even_when_stringified_file_exists(intake, value):
+    intake.file(str(value))
+    status, _ = intake.submit('Read this', [{'path': value}])
+    assert status == 400
+    assert not intake.calls
+
+
+def test_filename_alias_and_attachment_cap(intake):
+    att = intake.file()
+    att['filename'] = att.pop('name')
+    assert intake.submit('Read', [att] * 21)[0] == 200
+    assert len(intake.calls[-1]['attachments']) == 20
+    assert intake.calls[-1]['msg'].count(att['path']) == 20
+
+
+def test_mixed_native_image_and_document_keep_references(intake):
+    image = intake.file()
+    document = intake.file('report.pdf')
+    document.update(mime='application/pdf', is_image=False)
+    assert intake.submit('Compare', [image, document])[0] == 200
+    turn = intake.calls[-1]
+    content = _build_native_multimodal_message(
+        '', turn['msg'], turn['attachments'], str(intake.workspace),
+        cfg={'agent': {'image_input_mode': 'native'}})
+    assert content[0] == {'type': 'text', 'text': turn['msg']}
+    assert image['path'] in content[0]['text']
+    assert document['path'] in content[0]['text']
+    assert len(content) == 2
+    assert content[1]['type'] == 'image_url'
+    assert content[1]['image_url']['url'].startswith('data:image/jpeg;base64,')
+
+
+def test_relative_workspace_reference_is_canonical_for_text_and_embedding(intake):
+    att = intake.file('photo [1].jpg')
+    absolute = att['path']
+    att['path'] = att['name']
+    assert intake.submit('Read', [att])[0] == 200
+    turn = intake.calls[-1]
+    assert turn['attachments'][0]['path'] == absolute
+    assert turn['msg'] == f'Read\n\n[Attached files: {absolute}]'
+
+
+def test_rejected_request_does_not_modify_existing_pending_turn(intake):
+    intake.session.pending_user_message = 'Original turn'
+    intake.session.pending_attachments = [{'path': '/original/file.jpg'}]
+    before = copy.deepcopy(intake.session.__dict__)
+    assert intake.submit('New turn', [{'path': '/missing/file.jpg'}])[0] == 400
+    assert intake.session.__dict__ == before
+    assert not intake.calls
+
+
+def test_new_turn_does_not_reuse_previous_attachments(intake):
+    att = intake.file()
+    assert intake.submit('First', [att])[0] == 200
+    assert intake.submit('Second')[0] == 200
+    assert att['path'] in intake.calls[0]['msg']
+    assert intake.calls[1]['msg'] == 'Second'
+    assert intake.calls[1]['attachments'] == []


### PR DESCRIPTION
## Thinking Path

`/api/chat/start` accepts structured attachments, but text-mode delivery depended on the browser appending file references to the message. An API client could upload a file and submit its metadata successfully without giving the Agent a usable reference.

This PR moves that formatting to the server and removes the browser-side formatter, giving browser and API clients the same attachment handoff.

## What Changed

- Build attachment-reference text from structured metadata before persistence, journalling and worker dispatch.
- Accept attachment-only requests, using `Uploaded: <filename>` as the fallback text.
- Resolve attachment paths against the existing permitted roots and reject invalid references before dispatch.
- Reject non-string paths rather than coercing them.
- Send raw message text and structured attachments from the browser.
- Keep attachment references out of display/title text where appropriate.
- Reuse stored messages during regeneration without formatting them again.
- Document the handoff and add regression coverage.

## Why It Matters

Clients no longer need to reproduce undocumented browser formatting to make uploaded files accessible to the Agent. Persisted and dispatched message text share one server-owned representation, without introducing another endpoint or changing Hermes Agent.

## Contract Routing

- **Task type:** chat attachment handoff bug fix.
- **Touched areas:** request admission, attachment validation, persistence/dispatch consistency, browser submission and display/title handling.
- **Relevant documents:** `CONTRIBUTING.md`, `docs/CONTRACTS.md`, `ARCHITECTURE.md` and the WebUI run-state consistency contract.
- **Evidence:** focused automated tests and live browser/API-client attachment checks.
- **Scope boundary:** attachment delivery, not regeneration history reconciliation.

## Contract Change

Previously, the browser constructed model-facing attachment references. Fresh requests now supply raw text and structured attachment metadata; the server constructs the references.

The bundled browser is updated together with the server. There is no migration of saved history or compatibility shim for clients that already append the suffix themselves.

## Verification

- 250 focused tests passed.
- JavaScript runtime lint, relevant Ruff checks and Git whitespace checks passed.
- Automated coverage includes text-only and attachment-only admission, multiple files, mixed image/document input, invalid paths, permitted-root enforcement, persistence/journal/worker consistency, and regeneration without reformatting.
- Live checks confirmed readable images from both browser and Hermex Android, mixed image/PDF delivery, attachment-only delivery, and reopening an earlier attachment without reattaching it.
- Full-suite verification was not completed. Before/after UI screenshots are not included.

## Risks / Follow-ups

Regeneration testing exposed a separate context-duplication defect, also reproduced on unmodified upstream baseline `b1286878a437d374d2bfb6db3e3d084e33d3fe5d`.

The existing settlement path can retain both the original user checkpoint and its replacement when their provider-facing payloads differ, while displaying only one prompt. An isolated backend reproduction also demonstrated this with plain text.

This PR does not fix that upstream history-reconciliation defect and does not claim duplication-free regeneration. Its regeneration coverage verifies that attachment formatting is not applied again.

Path validation is security-sensitive. The change reuses the existing permitted roots; it does not grant additional filesystem access.

## Release Note

Attachment references are now constructed server-side, allowing browser and API clients to submit structured attachments consistently, including attachment-only messages.