### PR TITLE
fix(api): scan to first complete exchange for title regeneration (#7543)

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4025,11 +4025,11 @@ def _first_exchange_snippets(messages):
         role = m.get('role')
         if role == 'user':
             candidate = _strip_thinking_markup(_title_exchange_input_text(m.get('content')))
-            if not user_text and candidate:
+            if candidate and not user_text:
                 user_text = candidate
-                continue
-            if user_text and candidate:
-                break
+            # Issue #7543: keep scanning past consecutive user rows (queued
+            # first turns) until the first complete user+assistant pair —
+            # aborting here left asst_text empty -> missing_exchange fallback.
         elif role == 'assistant' and user_text:
             candidate = _message_text(m.get('content'))
             # Skip tool-call preambles *only* when content is empty or looks
@@ -5097,8 +5097,16 @@ def generate_session_title_for_session(session, *, prefer_latest: bool = False, 
     messages = getattr(session, 'messages', None) or []
     if prefer_latest:
         user_text, assistant_text = _latest_exchange_snippets(messages)
+        if not user_text:
+            return None, 'empty_user_message', ''
     else:
         user_text, assistant_text = _first_exchange_snippets(messages)
+        if not user_text:
+            # Issue #7543: scrubbing can empty the opening user message; fall
+            # back to the last complete exchange instead of empty_user_message.
+            fb_user, fb_asst = _latest_exchange_snippets(messages)
+            if fb_user and fb_asst:
+                user_text, assistant_text = fb_user, fb_asst
     if not user_text:
         return None, 'empty_user_message', ''
     from api import profiles as profiles_api

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -5097,16 +5097,8 @@ def generate_session_title_for_session(session, *, prefer_latest: bool = False, 
     messages = getattr(session, 'messages', None) or []
     if prefer_latest:
         user_text, assistant_text = _latest_exchange_snippets(messages)
-        if not user_text:
-            return None, 'empty_user_message', ''
     else:
         user_text, assistant_text = _first_exchange_snippets(messages)
-        if not user_text:
-            # Issue #7543: scrubbing can empty the opening user message; fall
-            # back to the last complete exchange instead of empty_user_message.
-            fb_user, fb_asst = _latest_exchange_snippets(messages)
-            if fb_user and fb_asst:
-                user_text, assistant_text = fb_user, fb_asst
     if not user_text:
         return None, 'empty_user_message', ''
     from api import profiles as profiles_api

--- a/tests/test_issue7543_title_first_exchange.py
+++ b/tests/test_issue7543_title_first_exchange.py
@@ -1,26 +1,16 @@
-"""Regression coverage for local hotfix of nesquena/hermes-webui#7543.
+"""Regression coverage for nesquena/hermes-webui#7543.
 
 Bug: manual "Regenerate title" failed with missing_exchange for sessions
 whose transcript opens with consecutive user rows (no assistant text before
 the second user turn) — _first_exchange_snippets() aborted at the second
 user message, the aux call was skipped, and the deterministic local fallback
 was persisted (200 + identical wrong title on every retry).
-
-LOCAL UNCOMMITTED HOTFIX — intentionally not upstreamed. The working-tree
-changes are captured in /root/workspace/local-7543.patch; originals in
-/root/workspace/7543-localpatch-backup/.
 """
 
-import sys
-from pathlib import Path
 from unittest.mock import MagicMock
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
-
-import api.profiles as profiles_api  # noqa: E402
-import api.streaming as streaming  # noqa: E402
+import api.profiles as profiles_api
+import api.streaming as streaming
 
 
 class _ProfileEnv:

--- a/tests/test_issue7543_title_first_exchange.py
+++ b/tests/test_issue7543_title_first_exchange.py
@@ -1,0 +1,167 @@
+"""Regression coverage for local hotfix of nesquena/hermes-webui#7543.
+
+Bug: manual "Regenerate title" failed with missing_exchange for sessions
+whose transcript opens with consecutive user rows (no assistant text before
+the second user turn) — _first_exchange_snippets() aborted at the second
+user message, the aux call was skipped, and the deterministic local fallback
+was persisted (200 + identical wrong title on every retry).
+
+LOCAL UNCOMMITTED HOTFIX — intentionally not upstreamed. The working-tree
+changes are captured in /root/workspace/local-7543.patch; originals in
+/root/workspace/7543-localpatch-backup/.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import api.profiles as profiles_api  # noqa: E402
+import api.streaming as streaming  # noqa: E402
+
+
+class _ProfileEnv:
+    def __enter__(self):
+        return None
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def _capturing_llm_result(captured, title="LLM Title", status="llm_aux"):
+    def _fake(user_text, assistant_text, **kwargs):
+        captured["user_text"] = user_text
+        captured["assistant_text"] = assistant_text
+        return title, status, ""
+
+    return _fake
+
+
+def _run_generation(monkeypatch, messages, captured, prefer_latest=False):
+    monkeypatch.setattr(profiles_api, "profile_env_for_background_worker", lambda *a, **k: _ProfileEnv())
+    monkeypatch.setattr(streaming, "_aux_title_generation_enabled", lambda: True)
+    monkeypatch.setattr(streaming, "_generate_llm_session_title_via_aux", _capturing_llm_result(captured))
+    session = MagicMock()
+    session.messages = messages
+    session.session_id = "issue7543"
+    return streaming.generate_session_title_for_session(session, prefer_latest=prefer_latest)
+
+
+# --- Fix A: _first_exchange_snippets scans past consecutive user rows ---
+
+
+def test_first_exchange_snippets_scan_past_consecutive_user_rows():
+    # Channel-backed import/projection shape: opening run of user rows,
+    # first assistant answer only much later (#7543 repro shape).
+    messages = [
+        {"role": "user", "content": "Opening question about certificates"},
+        {"role": "user", "content": "Follow-up that used to trigger the break"},
+        {"role": "user", "content": "Another queued user turn"},
+        {"role": "assistant", "content": "## Real first answer with substance"},
+    ]
+    user_text, asst_text = streaming._first_exchange_snippets(messages)
+    assert user_text == "Opening question about certificates"
+    assert asst_text == "## Real first answer with substance"
+
+
+def test_first_exchange_snippets_normal_pair_unchanged():
+    # Classic [user, assistant] opening must keep its exact behavior.
+    messages = [
+        {"role": "user", "content": "Please fix the stale sidebar title controls"},
+        {"role": "assistant", "content": "I will add a regenerate-title action."},
+        {"role": "user", "content": "Second question"},
+    ]
+    user_text, asst_text = streaming._first_exchange_snippets(messages)
+    assert user_text == "Please fix the stale sidebar title controls"
+    assert asst_text == "I will add a regenerate-title action."
+
+
+def test_first_exchange_snippets_without_any_assistant_text_still_empty():
+    # No assistant text anywhere -> still unusable for the LLM path; the
+    # missing_exchange rejection in generate_title_raw_via_aux stays intact.
+    messages = [
+        {"role": "user", "content": "Question one"},
+        {"role": "user", "content": "Question two"},
+    ]
+    user_text, asst_text = streaming._first_exchange_snippets(messages)
+    assert user_text == "Question one"
+    assert asst_text == ""
+
+
+def test_issue7543_real_transcript_shape_reaches_llm_path(monkeypatch):
+    captured = {}
+    messages = [
+        {"role": "user", "content": "Wie kann ich auf einem windows server 2025 ein zertifikat erstellen"} ,
+        {"role": "user", "content": "Wächst das Log so nicht in eine unendliche Schleife"},
+        {"role": "assistant", "content": "## Zertifikat für Windows Admin Center mit AD-CS"},
+    ]
+    title, status, _raw = _run_generation(monkeypatch, messages, captured)
+    assert status == "llm_aux"
+    assert title == "LLM Title"
+    assert captured["user_text"].startswith("Wie kann ich auf einem windows server 2025")
+    assert captured["assistant_text"].startswith("## Zertifikat")
+
+
+# --- Fix B: fallback to last complete exchange when first exchange unusable ---
+#
+# NOTE: both walkers share text extraction, so a "scrubbed message" transcript
+# is handled identically by pre- and post-fix code (verified against the
+# pre-fix module). To actually pin Fix B's discriminator — first walker yields
+# no user text, latest walker yields a complete pair — the walkers are mocked.
+# The transcript-level scrubber case stays covered by the mocked-walker test's
+# transcript comment and by Fix A tests at snippet level.
+
+
+def test_regenerate_helper_falls_back_when_first_exchange_yields_no_user_text(monkeypatch):
+    """Fix B discriminator: first exchange unusable, latest exchange usable."""
+    captured = {}
+    monkeypatch.setattr(streaming, "_first_exchange_snippets", lambda msgs: ("", ""))
+    monkeypatch.setattr(
+        streaming, "_latest_exchange_snippets", lambda msgs: ("Latest question", "Latest answer")
+    )
+    title, status, _raw = _run_generation(monkeypatch, [{"role": "assistant", "content": "x"}], captured)
+    assert status == "llm_aux"
+    assert title == "LLM Title"
+    assert captured["user_text"] == "Latest question"
+    assert captured["assistant_text"] == "Latest answer"
+
+
+def test_regenerate_helper_still_errors_when_neither_walker_yields_exchange(monkeypatch):
+    """Original error path: both walkers unusable -> empty_user_message."""
+    captured = {}
+    monkeypatch.setattr(streaming, "_first_exchange_snippets", lambda msgs: ("", ""))
+    monkeypatch.setattr(streaming, "_latest_exchange_snippets", lambda msgs: ("", ""))
+    title, status, _raw = _run_generation(monkeypatch, [{"role": "assistant", "content": "x"}], captured)
+    assert title is None
+    assert status == "empty_user_message"
+    assert "user_text" not in captured  # aux path never reached
+
+
+def test_regenerate_helper_prefer_latest_path_unchanged(monkeypatch):
+    captured = {}
+    messages = [
+        {"role": "user", "content": "First question"},
+        {"role": "assistant", "content": "First answer"},
+        {"role": "user", "content": "Latest question"},
+        {"role": "assistant", "content": "Latest answer"},
+    ]
+    title, status, _raw = _run_generation(monkeypatch, messages, captured, prefer_latest=True)
+    assert status == "llm_aux"
+    assert captured["user_text"] == "Latest question"
+    assert captured["assistant_text"] == "Latest answer"
+
+
+def test_regenerate_helper_prefer_latest_with_empty_last_user_message_errors(monkeypatch):
+    captured = {}
+    messages = [
+        {"role": "user", "content": "First question"},
+        {"role": "assistant", "content": "First answer"},
+        {"role": "user", "content": "   "},
+    ]
+    title, status, _raw = _run_generation(monkeypatch, messages, captured, prefer_latest=True)
+    assert title is None
+    assert status == "empty_user_message"
+    assert "user_text" not in captured

--- a/tests/test_issue7543_title_first_exchange.py
+++ b/tests/test_issue7543_title_first_exchange.py
@@ -22,9 +22,14 @@ class _ProfileEnv:
 
 
 def _capturing_llm_result(captured, title="LLM Title", status="llm_aux"):
+    # Guard-faithful stand-in for the aux route: mirrors the documented
+    # generate_title_raw_via_aux contract — empty assistant_text is rejected
+    # with missing_exchange (the provider edge), never the selection logic.
     def _fake(user_text, assistant_text, **kwargs):
         captured["user_text"] = user_text
         captured["assistant_text"] = assistant_text
+        if not user_text or not assistant_text:
+            return None, "missing_exchange", ""
         return title, status, ""
 
     return _fake
@@ -95,36 +100,12 @@ def test_issue7543_real_transcript_shape_reaches_llm_path(monkeypatch):
     assert captured["assistant_text"].startswith("## Zertifikat")
 
 
-# --- Fix B: fallback to last complete exchange when first exchange unusable ---
-#
-# NOTE: both walkers share text extraction, so a "scrubbed message" transcript
-# is handled identically by pre- and post-fix code (verified against the
-# pre-fix module). To actually pin Fix B's discriminator — first walker yields
-# no user text, latest walker yields a complete pair — the walkers are mocked.
-# The transcript-level scrubber case stays covered by the mocked-walker test's
-# transcript comment and by Fix A tests at snippet level.
-
-
-def test_regenerate_helper_falls_back_when_first_exchange_yields_no_user_text(monkeypatch):
-    """Fix B discriminator: first exchange unusable, latest exchange usable."""
+def test_regenerate_helper_errors_with_real_walkers_when_no_user_text_exists(monkeypatch):
+    """Observable error path through the real walkers: no user text anywhere
+    (orphan assistant rows only) -> empty_user_message, aux never called."""
     captured = {}
-    monkeypatch.setattr(streaming, "_first_exchange_snippets", lambda msgs: ("", ""))
-    monkeypatch.setattr(
-        streaming, "_latest_exchange_snippets", lambda msgs: ("Latest question", "Latest answer")
-    )
-    title, status, _raw = _run_generation(monkeypatch, [{"role": "assistant", "content": "x"}], captured)
-    assert status == "llm_aux"
-    assert title == "LLM Title"
-    assert captured["user_text"] == "Latest question"
-    assert captured["assistant_text"] == "Latest answer"
-
-
-def test_regenerate_helper_still_errors_when_neither_walker_yields_exchange(monkeypatch):
-    """Original error path: both walkers unusable -> empty_user_message."""
-    captured = {}
-    monkeypatch.setattr(streaming, "_first_exchange_snippets", lambda msgs: ("", ""))
-    monkeypatch.setattr(streaming, "_latest_exchange_snippets", lambda msgs: ("", ""))
-    title, status, _raw = _run_generation(monkeypatch, [{"role": "assistant", "content": "x"}], captured)
+    messages = [{"role": "assistant", "content": "orphan answer without any user turn"}]
+    title, status, _raw = _run_generation(monkeypatch, messages, captured)
     assert title is None
     assert status == "empty_user_message"
     assert "user_text" not in captured  # aux path never reached


### PR DESCRIPTION
Fixes #7543

## Thinking Path

- Hermes WebUI generates session titles from the transcript via an auxiliary
  LLM call, with a deterministic local fallback when the LLM path fails.
- Manual "Regenerate title" always feeds the **first** exchange into the LLM
  (the frontend never sends `prefer_latest`).
- For sessions whose transcript opens with a run of consecutive `user` rows
  (channel-backed imports/projections), the first-exchange snippet walker
  aborted at the *second* user message before collecting any assistant text.
- With `assistant_text == ''`, the aux call rejects with `missing_exchange`,
  the fallback title is persisted with HTTP 200, and every retry reproduces
  the identical wrong title — the failure is invisible in the UI.
- The issue's suggested fix sketch #1 (walker keeps scanning for the first
  assistant turn) alone resolves the reported shape: with the fixed walker,
  every transcript that contains a usable opening user message plus any
  following assistant text reaches the LLM. This PR implements exactly that,
  and nothing more.

## What Changed

`api/streaming.py`, one function, +8/−4:

`_first_exchange_snippets()`: a second consecutive `user` row no longer
triggers `break`; the walker keeps scanning until the first complete
user+assistant pair (empty assistant preambles/tool-call-only rows are still
skipped, `user_text[:500]/asst_text[:500]` clipping unchanged).

New: `tests/test_issue7543_title_first_exchange.py` (7 tests, see Verification).

Not changed (deliberate scope cuts, see Risks / Follow-ups):
`generate_title_raw_via_aux()`'s `missing_exchange` guard stays (correct
defense-in-depth for other callers); the `llm_title_generated` flag
semantics from the issue sketch are NOT addressed here; the frontend still
sends only `{session_id}`; no regenerate-handler latest-exchange fallback
was added (see Verification for why sketch #2's fallback turned out to be
unreachable dead code — happy to add it in a follow-up if a maintainer
points at a reachable shape).

## Why It Matters

- Sessions stuck with a fallback title could never be fixed by the user:
  regenerate always returned the same deterministic title, and because the
  fallback had already been persisted with `llm_title_generated: true`, the
  adaptive/auto-refresh path also refused to retry. The only escape was the
  undocumented `prefer_latest` body parameter.
- Title quality affects session identification in the sidebar, insights
  sync, and share links — every downstream consumer of `session.title`.

## Verification

- **Repo runner:** `./scripts/test.sh tests/test_issue7543_title_first_exchange.py tests/test_session_title_regenerate_controls.py tests/test_title_sanitization.py tests/test_issue6814_title_generation_enabled_gate.py tests/test_issue3987_imported_session_titles.py` → **56 passed** (Python 3.13, repo `.venv`).
- **Test fails before the fix, and no mock stands in for the selection
  logic under test:** the aux LLM call is the only mock, and it is
  *guard-faithful* — it mirrors the documented `generate_title_raw_via_aux`
  contract (empty `assistant_text` → `missing_exchange`) instead of
  unconditionally succeeding, so the selection logic's effect on the
  endpoint response is observable end-to-end:
  - Loaded the pristine pre-PR `api/streaming.py` as a standalone module and
    ran the new E2E expectation against it: the issue-pinned transcript
    shape (3 consecutive user rows, assistant answer only after them)
    yields `local_summary:missing_exchange` → the new E2E test fails; the
    patched module returns `llm_aux` with the opening user turn plus the
    first following assistant text.
  - Snippet-level: the original walker returns `asst_text == ''` for the
    issue shape → `test_first_exchange_snippets_scan_past_consecutive_user_rows`
    fails; patched walker passes.
- **Issue-pinned shape:** the issue pins the trigger as "first exchange has
  no assistant text" (`user_text != ''`, `asst_text == ''` at the second
  consecutive user row). The snippet test and the E2E test both use exactly
  that shape; a third test pins the empty-assistant side of the guard
  (`missing_exchange` rejection stays intact for transcripts without any
  assistant text).
- **Why the earlier mocked-walker fallback test was dropped** (Greptile
  review): an exhaustive enumeration of realistic transcript shapes
  (5,460 combinations of user/empty-user/assistant/tool-call-preamble rows,
  lengths 1–6) shows the "first walker yields no user text while the latest
  walker yields a complete pair" state is *unreachable* from real
  transcripts — both walkers share the same text extraction, and the
  forward walker scans every message. The mocked test verified fabricated
  internal state, not observable behavior, and the fallback branch it
  covered was dead code; it was removed in
  `test(api): drop mocked-walker fallback …` rather than defended.
- **Live reproduction** on the local install (session with 11 consecutive
  user rows, first assistant row at index 11): pre-fix in-process snippet
  check → `asst_text == ''` (would be `missing_exchange`); post-fix live
  `POST /api/session/title/regenerate` without `prefer_latest` →
  `{"status":"llm_aux"}` with a generated title persisted. No
  `missing_exchange` in server logs since.
- **Claims owned outside the repo:** the OpenRouter completion round-trip in
  the live check is owned by OpenRouter; the repo-owned proof is the mocked
  aux call in tests plus the API status contract (`llm_aux`), not the
  provider's answer quality.

## Contract Routing

- Task type: bug fix (behavior change in title generation exchange selection)
- Touched areas: `api/streaming.py` (session title generation helpers)
- Relevant public docs: `CONTRIBUTING.md` (PR process), `AGENTS.md`
  (contribution style, state-layer naming), `docs/CONTRACTS.md` (routing
  section), `ARCHITECTURE.md` (no section describes title-generation
  exchange selection — nothing to update), `TESTING.md` (runner usage —
  followed, not changed)
- Scope boundaries: no API request/response shape change (endpoint still
  returns `{session, title, status, raw_preview}`; `status` values are
  unchanged — only *which* snippets reach the LLM changes); no persistence
  schema change (`llm_title_generated`, `manual_title` semantics untouched);
  no frontend change.
- State layer mutated: none — the fix only chooses different *input
  snippets* for an existing LLM call; persistence still flows through
  `_persist_generated_session_title` (routes.py) unchanged. Invariant proof:
  when no user text exists at all, the function still returns
  `(None, 'empty_user_message', '')` exactly as before (regression test
  included, real walkers); `require_default_title` callers are unaffected
  because the helper's contract (return `(title, status, raw_preview)`) is
  unchanged.
- Not an intentional contract change → no `Contract Change` section needed.

## Risks / Follow-ups

- **Risk (low):** sessions whose *second* user message carries the "real"
  topic now get a title from the *first* user message (previously they got
  the fallback title — also derived from the first user message — so the
  observable difference is fallback-vs-LLM phrasing, not a different
  exchange choice).
- **Follow-up (out of scope here):** the `llm_title_generated` flag
  semantics ("don't mark fallback titles as LLM-generated") from the issue
  discussion — needs its own PR with coverage over the background title path
  to avoid regressing auto-refresh eligibility.
- **Follow-up (out of scope here):** UI surface for `prefer_latest`
  (frontend currently sends only `{session_id}`); would need UX + i18n work
  per `docs/UIUX-GUIDE.md` with before/after images.
- Siblings considered (GUIDELINES #1): `_latest_exchange_snippets` has no
  abort-at-second-user bug (walks backwards, pairing verified); the agent
  route `generate_title_raw_via_agent` shares only the `missing_exchange`
  guard, which is correct there; background path `_background_title_inputs`
  requires `user_text and assistant_text` and silently skips — a follow-up
  could retry with the latest exchange there too, but that changes auto
  eligibility behavior and is out of scope for this bug fix.
- Could not verify: behavior on transcripts where every assistant row is a
  tool-call-only preamble (walker still returns `asst_text == ''` → same
  failure class remains possible; the missing_exchange guard stays correct);
  no mobile/desktop UI evidence needed (no UI change).

**Release-note wording (for the release workflow, not CHANGELOG.md):**

> Session title regeneration no longer fails with `missing_exchange` for
> transcripts whose first exchange contains no assistant text: the
> first-exchange walker now scans to the first complete user+assistant pair
> instead of aborting at a second consecutive user message (#7543).

## Model Used

- Provider: Z.ai via OpenRouter (`z-ai/glm-5.3-flash`) as the interactive
  coding assistant (Hermes Agent), with deepseek/deepseek-v4-flash exercised
  as the repo-configured auxiliary title model during live verification.
- Notable tooling: local verification ran `./scripts/test.sh` (repo venv);
  fail-before proof loaded the pre-PR module standalone; the change is a
  focused commit series built from those working-tree edits.

## AI Usage Disclosure

- Provider: z-ai / OpenRouter
- Model: z-ai/glm-5.3-flash (Hermes Agent runtime)
- Notable use: test authoring and diff verification assisted by the agent;
  root-cause analysis reproduced locally against the pinned issue shape.